### PR TITLE
Critical bug fix for the boss reward system.

### DIFF
--- a/data/scripts/creaturescripts/others/boss_reward_chest.lua
+++ b/data/scripts/creaturescripts/others/boss_reward_chest.lua
@@ -122,6 +122,11 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 	if not creature or creature:isPlayer() then
 		return true
 	end
+	
+	-- Deny summons
+    if creature:getMaster() then
+        return true
+    end
 
 	-- boss
 	local monsterType = creature:getType()


### PR DESCRIPTION
This should fix an issue reported by Drume that actually allows to get infinite rewards when you're killing the boss summons (falcon minibosses).