### PR TITLE
Fix container reward key

### DIFF
--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -68,7 +68,6 @@ local function playerAddContainerItem(params, item)
 
 	local reward = params.containerReward
 	local itemType = ItemType(params.itemid)
-	
 	if itemType:isKey() then
 		-- If is key inside container, uses the "keyAction" variable
 		keyItem = reward:addItem(params.itemid, params.count)

--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -88,7 +88,6 @@ local function playerAddContainerItem(params, item)
 		player:addAchievement(achievement)
 	end
 
-	reward:addItem(params.itemid, params.count)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have found a " .. getItemName(params.itemBagName) .. ".")
 	player:setStorageValue(params.storage, 1)
 	return true

--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -67,12 +67,19 @@ local function playerAddContainerItem(params, item)
 	local player = params.player
 
 	local reward = params.containerReward
-	if params.action then
-		local itemType = ItemType(params.itemid)
-		if itemType:isKey() then
-			-- If is key inside container, uses the "keyAction" variable
-			keyItem = reward:addItem(params.itemid, params.count)
+	local itemType = ItemType(params.itemid)
+	
+	if itemType:isKey() then
+		-- If is key inside container, uses the "keyAction" variable
+		keyItem = reward:addItem(params.itemid, params.count)
+		if params.storage then
 			keyItem:setActionId(params.action)
+		end
+	else
+		reward:addItem(params.itemid, params.count)
+		local attribute = AttributeTable[item.uid]
+		if attribute then
+			addItem:setAttribute(ITEM_ATTRIBUTE_TEXT, attribute.text)
 		end
 	end
 


### PR DESCRIPTION
# Description

The key from the container reward had the wrong (four-zero) number.

## Behavior
### Actual

When You open quest chest, reward in container containing key will you receive have wrong action number. Good example is Emperor's cookies quest key 3801.

### Expected

When You open quest chest, reward in container containing key will you receive have GOOD action number.

## Fixes

 #325

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

On the example of Emperor's cookies quest:
  - [x] Open quest chest with reward without container [working correctly]
  - [x] Open quest chest with reward in container [working correctly]

## Test Configuration:

  - Server Version: 12.64 (otbr main)
  - Client: 12.64
  - Operating System: Debian Buster (Server) / Windows 10 (Client)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ]  I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is ​​effective or that my feature works