### PR TITLE
[Fix] first dragon quest treasure chest

### DIFF
--- a/data/scripts/actions/quests/first_dragon/treasure_chest.lua
+++ b/data/scripts/actions/quests/first_dragon/treasure_chest.lua
@@ -21,7 +21,6 @@ local UniqueTable = {
 	},
 	[14006] = {
 		itemId = 2156,
-		name = "red gem",
 		count = 1
 	},
 	[14007] = {
@@ -104,7 +103,7 @@ function treasureChest.onUse(player, item, fromPosition, target, toPosition, isH
 	player:addItem(setting.name or setting.itemId, setting.count, true)
 	player:setStorageValue(item.uid, 1)
 	player:setStorageValue(Storage.FirstDragon.ChestCounter, player:getStorageValue(Storage.FirstDragon.ChestCounter) + 1)
-	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' ..setting.name..'.')
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' .. getItemName(setting.itemId) .. '.')
 	return true
 end
 

--- a/data/scripts/actions/quests/first_dragon/treasure_chest.lua
+++ b/data/scripts/actions/quests/first_dragon/treasure_chest.lua
@@ -85,7 +85,7 @@ local treasureChest = Action()
 function treasureChest.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local setting = UniqueTable[item.uid]
 	if not setting then
-		return true
+		return false
 	end
 
 	if player:getStorageValue(item.uid) >= 1 then

--- a/data/scripts/actions/quests/first_dragon/treasure_chest.lua
+++ b/data/scripts/actions/quests/first_dragon/treasure_chest.lua
@@ -100,10 +100,15 @@ function treasureChest.onUse(player, item, fromPosition, target, toPosition, isH
 		player:setStorageValue(Storage.FirstDragon.ChestCounter, player:getStorageValue(Storage.FirstDragon.ChestCounter) + 1)
 		return true
 	end
-	player:addItem(setting.name or setting.itemId, setting.count, true)
 	player:setStorageValue(item.uid, 1)
 	player:setStorageValue(Storage.FirstDragon.ChestCounter, player:getStorageValue(Storage.FirstDragon.ChestCounter) + 1)
-	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' .. getItemName(setting.itemId) .. '.')
+	if setting.name then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' ..setting.name..'.')
+		player:addItem(setting.name, setting.count, true)
+	elseif setting.itemId then
+		player:addItem(setting.itemId, setting.count, true)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' .. getItemName(setting.itemId) .. '.')
+	end
 	return true
 end
 

--- a/data/scripts/actions/quests/first_dragon/treasure_chest.lua
+++ b/data/scripts/actions/quests/first_dragon/treasure_chest.lua
@@ -20,6 +20,7 @@ local UniqueTable = {
 		count = 2
 	},
 	[14006] = {
+		itemId = 2156,
 		name = "red gem",
 		count = 1
 	},
@@ -87,18 +88,20 @@ function treasureChest.onUse(player, item, fromPosition, target, toPosition, isH
 	if not setting then
 		return true
 	end
+
 	if player:getStorageValue(item.uid) >= 1 then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The ' .. getItemName(setting.itemId) .. ' is empty.')
+		player:sendTextMessage(string.format(MESSAGE_EVENT_ADVANCE, 'The %s is empty.', item:getName()))
 		return true
 	end
+
 	if player:getStorageValue(Storage.FirstDragon.ChestCounter) >= 19 then
 		player:addAchievement('Treasure Hunter')
-		player:addItem(setting.name, setting.count, true)
+		player:addItem(setting.name or setting.itemId, setting.count, true)
 		player:setStorageValue(item.uid, 1)
 		player:setStorageValue(Storage.FirstDragon.ChestCounter, player:getStorageValue(Storage.FirstDragon.ChestCounter) + 1)
 		return true
 	end
-	player:addItem(setting.name, setting.count, true)
+	player:addItem(setting.name or setting.itemId, setting.count, true)
 	player:setStorageValue(item.uid, 1)
 	player:setStorageValue(Storage.FirstDragon.ChestCounter, player:getStorageValue(Storage.FirstDragon.ChestCounter) + 1)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You found ' ..setting.count.. ' ' ..setting.name..'.')


### PR DESCRIPTION
# Description

The call to "getItemName(setting.itemId)" didn't exist, as it didn't have the itemId variable, I have modified to pull the chest name directly from the item.
Added the variable "itemId" so that it is possible to add an item by id, in case the item is "non-unique" (items of different ids with the same names)

NOTE: This will be used when adding 12.70+ items, as the red gem will no longer be a unique item.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
