### PR TITLE
Fix vcpkg/libmariadb package

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,7 +235,7 @@ else()
 			cryptopp-static
 			CURL::libcurl
 			jsoncpp_static
-			libmariadb mariadbclient
+			unofficial::libmariadb unofficial::mariadbclient
 			pugixml::pugixml
 			spdlog::spdlog
 			Threads::Threads

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,9 @@
     "boost-filesystem",
     "boost-iostreams",
     "boost-system",
-    "libmariadb",
+    { "name": "libmariadb",
+      "features": [ "mariadbclient" ]
+    },
     "pugixml",
     "spdlog",
     "curl",


### PR DESCRIPTION
# Description

Recent changes to vcpkg/libmariadb removed mariadbclient and made it an option instead.

## Behaviour
### **Actual**

Without this change, otservbr-global cannot be compiled following the standard instructions

### **Expected**

Compile successful 

## Fixes

Reported compiling issues on discord & otland

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Compiled on WSL Ubuntu 20.04

**Test Configuration**:

  - Server Version: main
  - Client: n/a
  - Operating System: WSL Ubuntu 20.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
