### PR TITLE
[Fix] Item charges from Boss reward.

### DIFF
--- a/data/lib/others/reward_boss_lib.lua
+++ b/data/lib/others/reward_boss_lib.lua
@@ -74,9 +74,16 @@ function MonsterType.createLootItem(self, lootBlock, chance, lootTable)
 		end
 	end
 
+	local charges, n = itemType:getCharges()
 	while itemCount > 0 do
-		local n = math.min(itemCount, 100)
-		itemCount = itemCount - n
+		if charges > 0 then
+			n = charges
+			itemCount = itemCount - 1
+		else
+			n = math.min(itemCount, 100)
+			itemCount = itemCount - n
+		end
+
 		table.insert(lootTable, {lootBlock.itemId, n})
 	end
 


### PR DESCRIPTION
# Description
- Reward system.

Items that contains '**charge**' attribute (E.g amulets) was being created without this attribute set, since this one was overwrited for '**itemcount**' instead of '**itemchange**'. This scenario only happens on creature labeled as **Boss**.

## Behaviour
### **Actual**

Loot on reward container is coming without charges.

### **Expected**

Porperly set attribute '**chage**' on the item when creating it.

## Fixes

\# (Reported on discord by users)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

  - [ ] Create a monster labeled as **Boss** that have a item with charges on it. (Magma amulet)
  - [ ] Kill it with a non admin character and account.
  - [ ] Open the reward bag and check the item charge iguals to 1.

**Test Configuration**:

  - Server Version: Any
  - Client: Any
  - Operating System: Any

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
