### PR TITLE
[Docker Enhancement] Otimize vcpkg clone and disk usage

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN apt-get install -y --no-install-recommends libluajit-5.1-dev unzip
 
 WORKDIR /opt
-RUN git clone https://github.com/microsoft/vcpkg
+RUN git clone https://github.com/microsoft/vcpkg --depth=1
 RUN ./vcpkg/bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg


### PR DESCRIPTION
# Description

Reduce cloning time and disk usage.

## Behaviour
### **Actual**

Download entire vcpkg repository.
objects: 134086
download size: 45.66 MiB

```
$ git clone https://github.com/microsoft/vcpkg
Cloning into 'vcpkg'...
remote: Enumerating objects: 134086, done.
remote: Counting objects: 100% (94/94), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 134086 (delta 81), reused 73 (delta 73), pack-reused 133992
Receiving objects: 100% (134086/134086), 45.66 MiB | 27.10 MiB/s, done.
Resolving deltas: 100% (82891/82891), done.
Updating files: 100% (8370/8370), done.
```

### **Expected**

Download only latest version of vcpkg with only last commit

objects: 10255
download size: 4.43 MiB

```
$ git clone https://github.com/microsoft/vcpkg --depth=1
Cloning into 'vcpkg'...
remote: Enumerating objects: 10255, done.
remote: Counting objects: 100% (10255/10255), done.
remote: Compressing objects: 100% (8598/8598), done.
remote: Total 10255 (delta 2242), reused 7906 (delta 1605), pack-reused 0
Receiving objects: 100% (10255/10255), 4.43 MiB | 12.88 MiB/s, done.
Resolving deltas: 100% (2242/2242), done.
Updating files: 100% (8370/8370), done.
```