### PR TITLE
Set default build to "RelWithDebInfo"

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -3,7 +3,7 @@
     {
       "name": "x64-Release",
       "generator": "Ninja",
-      "configurationType": "Release",
+      "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
       "cmakeCommandArgs": "",


### PR DESCRIPTION
# Description

Changed so that compilation with debug information is by default, thus facilitating visual studio debugger log.

## Type of change
  - [x] New feature (non-breaking change which adds functionality)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
