### PR TITLE
Fix links to compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You are subject to our code of conduct, read at [this link](https://github.com/o
 
 * **WARNING: YOU NEED TO UNZIP THE MAP BEFORE START THE SERVER.**
 * [Compiling on Windows](https://forums.otserv.com.br/index.php?/forums/topic/169235-windowsvc2019-compilando-sources-otservbr-global/), alternatively if you are ****not** going to change anything on the source** you can download the latest compiled version for windows from [nightly builds for Windows](https://ci.appveyor.com/project/opentibiabr/otservbr-global/build/artifacts).
-* Wiki: Compiling ([Ubuntu/Debian](https://github.com/opentibiabr/otservbr-global/wiki/Compiling-on-Ubuntu-or-Debian-GNU-Linux), [Windows](https://github.com/opentibiabr/otservbr-global/wiki/Compiling-on-Windows-(vcpkg)))
+* Wiki: Compiling ([Ubuntu/Debian](https://github.com/opentibiabr/otservbr-global/wiki/Compiling-on-Debian-or-Ubuntu), [Windows](https://github.com/opentibiabr/otservbr-global/wiki/Compiling-on-Windows))
 
 ### Issues
 


### PR DESCRIPTION
This is simple link fix in README.md

The links to Windows and Ubuntu/Debian compilation were not working.

I think it's self-explainatory.
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
