### PR TITLE
Fix lion's rock quest "holy water fountain" and "fountain rewards"

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <events>
 	<!-- Creature Methods -->
-	<event class="Creature" method="onChangeOutfit" enabled="1" />
 	<event class="Creature" method="onAreaCombat" enabled="0" />
-	<event class="Creature" method="onTargetCombat" enabled="1" /><!-- removeCombatProtection on secure modes protection -->
-	<event class="Creature" method="onHear" enabled="0" />
-
-	<!-- Party Methods -->
-	<event class="Party" method="onJoin" enabled="0" />
-	<event class="Party" method="onLeave" enabled="0" />
-	<event class="Party" method="onDisband" enabled="0" />
-	<event class="Party" method="onShareExperience" enabled="1" />
-
-	<!-- Player Methods -->
-	<event class="Player" method="onBrowseField" enabled="0" />
-	<event class="Player" method="onLook" enabled="1" />
-	<event class="Player" method="onLookInBattleList" enabled="1" />
-	<event class="Player" method="onLookInTrade" enabled="1" />
-	<event class="Player" method="onLookInShop" enabled="0" />
-	<event class="Player" method="onMoveItem" enabled="1" /><!-- Protections on rewardsystem and global depots -->
-	<event class="Player" method="onItemMoved" enabled="0" />
-	<event class="Player" method="onChangeZone" enabled="1" />
-	<event class="Player" method="onMoveCreature" enabled="1" />
-	<event class="Player" method="onReportBug" enabled="1" />
-	<event class="Player" method="onReportRuleViolation" enabled="1" />
-	<event class="Player" method="onTurn" enabled="1" /><!-- Move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
-	<event class="Player" method="onTradeRequest" enabled="1" /><!-- Move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
-	<event class="Player" method="onTradeAccept" enabled="1" />
-	<event class="Player" method="onGainExperience" enabled="1" />
-	<event class="Player" method="onLoseExperience" enabled="0" />
-	<event class="Player" method="onGainSkillTries" enabled="1" />
-	<event class="Player" method="onRequestQuestLog" enabled="1" />
-	<event class="Player" method="onRequestQuestLine" enabled="1" />
-	<event class="Player" method="onStorageUpdate" enabled="1" />
-	<event class="Player" method="onCombat" enabled="1" />
-
+	<event class="Creature" method="onChangeOutfit" enabled="1" />
 	<event class="Creature" method="onDrainHealth" enabled="1" />
-	<event class="Player" method="onRemoveCount" enabled="1" /><!-- Tibia 11 function -->
+	<event class="Creature" method="onHear" enabled="0" />
+	<event class="Creature" method="onTargetCombat" enabled="1" /><!-- removeCombatProtection on secure modes protection -->
 
 	<!-- Monster Methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />
 	<event class="Monster" method="onSpawn" enabled="1" />
+
+	<!-- Party Methods -->
+	<event class="Party" method="onDisband" enabled="0" />
+	<event class="Party" method="onJoin" enabled="0" />
+	<event class="Party" method="onLeave" enabled="0" />
+	<event class="Party" method="onShareExperience" enabled="1" />
+
+	<!-- Player Methods -->
+	<event class="Player" method="onBrowseField" enabled="0" />
+	<event class="Player" method="onChangeZone" enabled="1" />
+	<event class="Player" method="onGainExperience" enabled="1" />
+	<event class="Player" method="onGainSkillTries" enabled="1" />
+	<event class="Player" method="onItemMoved" enabled="1" />
+	<event class="Player" method="onLook" enabled="1" />
+	<event class="Player" method="onLookInBattleList" enabled="1" />
+	<event class="Player" method="onLookInShop" enabled="0" />
+	<event class="Player" method="onLookInTrade" enabled="1" />
+	<event class="Player" method="onLoseExperience" enabled="0" />
+	<event class="Player" method="onMoveCreature" enabled="1" />
+	<event class="Player" method="onMoveItem" enabled="1" /><!-- Protections on rewardsystem and global depots -->
+	<event class="Player" method="onReportBug" enabled="1" />
+	<event class="Player" method="onReportRuleViolation" enabled="1" />
+	<event class="Player" method="onRequestQuestLine" enabled="1" />
+	<event class="Player" method="onRequestQuestLog" enabled="1" />
+	<event class="Player" method="onStorageUpdate" enabled="1" />
+	<event class="Player" method="onTradeAccept" enabled="1" />
+	<event class="Player" method="onTradeRequest" enabled="1" /><!-- Move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
+	<event class="Player" method="onTurn" enabled="1" /><!-- Move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
+	<event class="Player" method="onCombat" enabled="1" />
+	<event class="Player" method="onRemoveCount" enabled="1" /><!-- Tibia 11 function -->
+
 </events>

--- a/data/scripts/actions/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/actions/quests/lions_rock/lions_rock.lua
@@ -127,7 +127,7 @@ local lionsGetLionsMane = Action()
 
 function lionsGetLionsMane.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 23759 then
-		if player:getStorageValue(Storage.LionsRock.Questline) > 0 then
+		if player:getStorageValue(Storage.LionsRock.Questline) < 0 then
 			if player:getStorageValue(Storage.LionsRock.GetLionsMane) < 0 then
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You picked a beautiful lion's mane flower.")
 				player:addItem(23760, 1)
@@ -150,7 +150,7 @@ function lionsGetHolyWater.onUse(player, item, fromPosition, target, toPosition,
 		return true
 	end
 
-	if player:getStorageValue(Storage.LionsRock.Questline) < 0 then
+	if player:getStorageValue(Storage.LionsRock.GetLionsMane) > 0 then
 		if player:getStorageValue(Storage.LionsRock.GetHolyWater) < 0 then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You took some holy water from the sacred well.')
 			player:addItem(23835, 1)

--- a/data/scripts/actions/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/actions/quests/lions_rock/lions_rock.lua
@@ -150,7 +150,7 @@ function lionsGetHolyWater.onUse(player, item, fromPosition, target, toPosition,
 		return true
 	end
 
-	if player:getStorageValue(Storage.LionsRock.Questline) > 0 then
+	if player:getStorageValue(Storage.LionsRock.Questline) < 0 then
 		if player:getStorageValue(Storage.LionsRock.GetHolyWater) < 0 then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'You took some holy water from the sacred well.')
 			player:addItem(23835, 1)
@@ -219,7 +219,7 @@ function lionsRockFountain.onUse(player, item, fromPosition, target, toPosition,
 
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
 			"Something sparkles in the fountain's water. You draw out a " .. rewards[reward] .. '.')
-		player:sendMagicEffect(CONST_ME_HOLYAREA)
+		player:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 		player:addAchievement("Lion's Den Explorer")
 		item:transform(lionsRockSanctuaryRockId)
 		player:addItem(rewards[reward], 1)


### PR DESCRIPTION
# Description

Fix, to get the Holy Water you need to collect the flower first. Currently when you try to get holy water, it doesn't work properly.
When you try to obtain reward from fountain you got nothing, and got error in console with "sentMagicEffect".

## Behaviour
### **Actual**

Use HolyWater Fountain - you get nothing, no errors.
Try to get reward - error in console with sendMagicEffect..

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: Main
  - Client: 12.72
  - Operating System: Ubuntu

