### PR TITLE
Amulet bug fix in werewolf amulet time

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -36876,9 +36876,6 @@
 		<attribute key="transformEquipTo" value="24790" />
 		<attribute key="showduration" value="1" />
 		<attribute key="stopduration" value="1" />
-		<attribute key="armor" value="3" />
-		<attribute key="absorbPercentPhysical" value="6" />
-		<attribute key="showattributes" value="1" />
 	</item>
 	<item id="24718" article="a" name="werewolf helmet">
 		<attribute key="weight" value="2500" />
@@ -37239,7 +37236,7 @@
 		<attribute key="weight" value="550" />
 		<attribute key="slotType" value="necklace" />
 		<attribute key="loottype" value="amulet" />
-		<attribute key="decayTo" value="0" />
+		<attribute key="decayTo" value="24716" />
 		<attribute key="transformDeEquipTo" value="24717" />
 		<attribute key="armor" value="3" />
 		<attribute key="absorbPercentPhysical" value="6" />
@@ -47713,7 +47710,6 @@
 		<attribute key="loottype" value="amulet" />
 		<attribute key="transformEquipTo" value="34980" />
 		<attribute key="stopduration" value="1" />
-		<attribute key="duration" value="3600" />
 		<attribute key="showduration" value="1" />
 	</item>
 	<item id="34982" article="an" name="enchanted pendulet">

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -37191,7 +37191,6 @@
 		<attribute key="transformEquipTo" value="24770" />
 		<attribute key="loottype" value="helmet" />
 		<attribute key="absorbPercentPhysical" value="4" />
-		<attribute key="skillSword" value="1" />
 		<attribute key="armor" value="9" />
 		<attribute key="showduration" value="1" />
 		<attribute key="stopduration" value="1" />

--- a/data/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data/scripts/movements/equipment/unscripted_equipments.lua
@@ -5224,6 +5224,16 @@ if not equipmentsTable then
 			slot = "necklace"
 		}, -- werewolf amulet
 		{
+            itemid = 24717,
+            type = "equip",
+            slot = "necklace"
+        }, -- enchanted werewolf amulet
+        {
+            itemid = 24717,
+            type = "deequip",
+            slot = "necklace"
+        }, -- enchanted werewolf amulet
+		{
 			itemid = 24637,
 			type = "equip",
 			slot = "feet",

--- a/data/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data/scripts/movements/equipment/unscripted_equipments.lua
@@ -5227,12 +5227,12 @@ if not equipmentsTable then
             itemid = 24717,
             type = "equip",
             slot = "necklace"
-        }, -- enchanted werewolf amulet
-        {
+		}, -- enchanted werewolf amulet
+		{
             itemid = 24717,
             type = "deequip",
             slot = "necklace"
-        }, -- enchanted werewolf amulet
+		}, -- enchanted werewolf amulet
 		{
 			itemid = 24637,
 			type = "equip",


### PR DESCRIPTION
# Description

Amulet bug fix in amulet time result (onDeEquip).

## Behaviour
### **Actual**

This PR is to fix amulets.

### **Expected**

Equip and unequip enchanted werewolf amulet or enchanted sleep shawl and the time will now decrease as expected.

## Fixes

#386

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Test A
  - [x] Test B

**Test Configuration**:

  - Server Version: Main
  - Client: 12.72
  - Operating System: Ubuntu 20.4

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
