### PR TITLE
[Fix] Bestiary counter logic and update charm values

### DIFF
--- a/data/scripts/modules/bestiary_charms.lua
+++ b/data/scripts/modules/bestiary_charms.lua
@@ -9,8 +9,8 @@ charm_t1.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as physical damage once."
 charm_t1.type = CHARM_OFFENSIVE
 charm_t1.damageType = COMBAT_PHYSICALDAMAGE
-charm_t1.percent = 10
-charm_t1.chance = 20
+charm_t1.percent = 5
+charm_t1.chance = 10
 charm_t1.messageCancel = "You wounded the monster."
 charm_t1.messageServerLog = "[Wound charm]"
 charm_t1.effect = CONST_ME_HITAREA
@@ -28,8 +28,8 @@ charm_t2.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as fire damage once."
 charm_t2.type = CHARM_OFFENSIVE
 charm_t2.damageType = COMBAT_FIREDAMAGE
-charm_t2.percent = 10
-charm_t2.chance = 20
+charm_t2.percent = 5
+charm_t2.chance = 10
 charm_t2.messageCancel = "You enflamed the monster."
 charm_t2.messageServerLog = "[Enflame charm]"
 charm_t2.effect = CONST_ME_HITBYFIRE
@@ -47,8 +47,8 @@ charm_t3.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as earth damage once."
 charm_t3.type = CHARM_OFFENSIVE
 charm_t3.damageType = COMBAT_EARTHDAMAGE
-charm_t3.percent = 10
-charm_t3.chance = 20
+charm_t3.percent = 5
+charm_t3.chance = 10
 charm_t3.messageCancel = "You poisoned the monster."
 charm_t3.messageServerLog = "[Poison charm]"
 charm_t3.effect = CONST_ME_GREEN_RINGS
@@ -66,8 +66,8 @@ charm_t4.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as ice damage once."
 charm_t4.type = CHARM_OFFENSIVE
 charm_t4.damageType = COMBAT_ICEDAMAGE
-charm_t4.percent = 10
-charm_t4.chance = 20
+charm_t4.percent = 5
+charm_t4.chance = 10
 charm_t4.messageCancel = "You frozen the monster."
 charm_t4.messageServerLog = "[Freeze charm]"
 charm_t4.effect = CONST_ME_ICEATTACK
@@ -85,8 +85,8 @@ charm_t5.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as energy damage once."
 charm_t5.type = CHARM_OFFENSIVE
 charm_t5.damageType = COMBAT_ENERGYDAMAGE
-charm_t5.percent = 10
-charm_t5.chance = 20
+charm_t5.percent = 5
+charm_t5.chance = 10
 charm_t5.messageCancel = "You eletrocuted the monster."
 charm_t5.messageServerLog = "[Zap charm]"
 charm_t5.effect = CONST_ME_ENERGYHIT
@@ -104,8 +104,8 @@ charm_t6.description = "Triggers on a creature with a certain chance and deals 5
 			of its initial hit points as death damage once."
 charm_t6.type = CHARM_OFFENSIVE
 charm_t6.damageType = COMBAT_DEATHDAMAGE
-charm_t6.percent = 10
-charm_t6.chance = 20
+charm_t6.percent = 5
+charm_t6.chance = 10
 charm_t6.messageCancel = "You curse the monster."
 charm_t6.messageServerLog = "[Curse charm]"
 charm_t6.effect = CONST_ME_SMALLCLOUDS
@@ -123,7 +123,7 @@ local charm_t7 = {}
 charm_t7.name = "Cripple"
 charm_t7.description = "Cripples the creature with a certain chance and paralyzes it for 10 seconds."
 charm_t7.type = CHARM_OFFENSIVE
-charm_t7.chance = 20
+charm_t7.chance = 10
 charm_t7.messageCancel = "You cripple the monster."
 charm_t7.points = 500
 
@@ -154,7 +154,7 @@ local charm_t9 = {}
 charm_t9.name = "Dodge"
 charm_t9.description = "Dodges an attack with a certain chance without taking any damage at all."
 charm_t9.type = CHARM_DEFENSIVE
-charm_t9.chance = 20
+charm_t9.chance = 10
 charm_t9.messageCancel = "You dodge the attack."
 charm_t9.effect = CONST_ME_POFF
 charm_t9.points = 600
@@ -170,7 +170,7 @@ charm_t10.name = "Adrenaline Burst"
 charm_t10.description = "Bursts of adrenaline enhance your reflexes with a certain chance \z
 			after you get hit and let you move faster for 10 seconds."
 charm_t10.type = CHARM_DEFENSIVE
-charm_t10.chance = 20
+charm_t10.chance = 10
 charm_t10.messageCancel = "Your movements where bursted."
 charm_t10.points = 500
 
@@ -184,7 +184,7 @@ local charm_t11 = {}
 charm_t11.name = "Numb"
 charm_t11.description = "Numbs the creature with a certain chance after its attack and paralyzes the creature for 10 seconds."
 charm_t11.type = CHARM_DEFENSIVE
-charm_t11.chance = 20
+charm_t11.chance = 10
 charm_t11.messageCancel = "You numb the monster."
 charm_t11.points = 500
 
@@ -199,7 +199,7 @@ charm_t12.name = "Cleanse"
 charm_t12.description = "Cleanses you from within with a certain chance after you get hit and \z
 			removes one random active negative status effect and temporarily makes you immune against it."
 charm_t12.type = CHARM_DEFENSIVE
-charm_t12.chance = 20
+charm_t12.chance = 10
 charm_t12.messageCancel = "You purified the attack."
 charm_t12.points = 700
 
@@ -229,7 +229,7 @@ local charm_t14 = {}
 charm_t14.name = "Scavenge"
 charm_t14.description = "Enhances your chances to successfully skin/dust a skinnable/dustable creature."
 charm_t14.type = CHARM_PASSIVE
-charm_t14.percent = 10
+charm_t14.percent = 25
 charm_t14.points = 800
 
 GLOBAL_CHARM_SCAVENGE = charm_t14.percent
@@ -273,8 +273,8 @@ charm_t17.description = "Triggers on a creature with a certain chance and deals 
 			of its initial hit points as holy damage once."
 charm_t17.type = CHARM_OFFENSIVE
 charm_t17.damageType = COMBAT_HOLYDAMAGE
-charm_t17.percent = 10
-charm_t17.chance = 20
+charm_t17.percent = 5
+charm_t17.chance = 10
 charm_t17.messageCancel = "You divine the monster."
 charm_t17.messageServerLog = "[Divine charm]"
 charm_t17.effect = CONST_ME_HOLYDAMAGE

--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -234,24 +234,17 @@ void IOBestiary::addBestiaryKill(Player* player, MonsterType* mtype, uint32_t am
 
 	player->addBestiaryKillCount(raceid, amount);
 
-	if (curCount == 0) {
-		player->sendBestiaryEntryChanged(raceid);
-		ss << "You unlocked details for the creature '" << mtype->name << "'";
-		player->sendTextMessage(MESSAGE_STATUS, ss.str());
-		return;
-	}
+	if ((curCount == 0) || // Initial kill stage
+		(curCount < mtype->info.bestiaryFirstUnlock && (curCount + amount) >= mtype->info.bestiaryFirstUnlock) || // First kill stage reached
+		(curCount < mtype->info.bestiarySecondUnlock && (curCount + amount) >= mtype->info.bestiarySecondUnlock) || // Second kill stage reached
+		(curCount < mtype->info.bestiaryToUnlock && (curCount + amount) >= mtype->info.bestiaryToUnlock)) { // Final kill stage reached
 
-	curCount += amount;
+		ss << "You unlocked details for the creature '" << mtype->name << "'";
+		player->sendTextMessage(MESSAGE_STATUS, ss.str());
+		player->sendBestiaryEntryChanged(raceid);
 
-	if ((curCount == mtype->info.bestiaryFirstUnlock) || (curCount == mtype->info.bestiarySecondUnlock)) {
-		ss << "You unlocked details for the creature '" << mtype->name << "'";
-		player->sendTextMessage(MESSAGE_STATUS, ss.str());
-		player->sendBestiaryEntryChanged(raceid);
-	} else if (curCount == mtype->info.bestiaryToUnlock) {
-		ss << "You unlocked details for the creature '" << mtype->name << "'";
-		player->sendTextMessage(MESSAGE_STATUS, ss.str());
-		addCharmPoints(player, mtype->info.bestiaryCharmsPoints);
-		player->sendBestiaryEntryChanged(raceid);
+		if ((curCount + amount) >= mtype->info.bestiaryToUnlock)
+			addCharmPoints(player, mtype->info.bestiaryCharmsPoints);
 	}
 
 	std::list<MonsterType*> trackerList = player->getBestiaryTrackerList();

--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -234,10 +234,10 @@ void IOBestiary::addBestiaryKill(Player* player, MonsterType* mtype, uint32_t am
 
 	player->addBestiaryKillCount(raceid, amount);
 
-	if ((curCount == 0) || // Initial kill stage
-		(curCount < mtype->info.bestiaryFirstUnlock && (curCount + amount) >= mtype->info.bestiaryFirstUnlock) || // First kill stage reached
-		(curCount < mtype->info.bestiarySecondUnlock && (curCount + amount) >= mtype->info.bestiarySecondUnlock) || // Second kill stage reached
-		(curCount < mtype->info.bestiaryToUnlock && (curCount + amount) >= mtype->info.bestiaryToUnlock)) { // Final kill stage reached
+	if ((curCount == 0) ||  // Initial kill stage
+		(curCount < mtype->info.bestiaryFirstUnlock && (curCount + amount) >= mtype->info.bestiaryFirstUnlock) ||  // First kill stage reached
+		(curCount < mtype->info.bestiarySecondUnlock && (curCount + amount) >= mtype->info.bestiarySecondUnlock) ||  // Second kill stage reached
+		(curCount < mtype->info.bestiaryToUnlock && (curCount + amount) >= mtype->info.bestiaryToUnlock)) {  // Final kill stage reached
 
 		ss << "You unlocked details for the creature '" << mtype->name << "'";
 		player->sendTextMessage(MESSAGE_STATUS, ss.str());


### PR DESCRIPTION
# Description

- Change bestiary kill counter logic to a better approach to handle custom amounts of kills per call.

- Update bestiary charm values following tibiaWIKI data.

## Behaviour
Increasing bestiary kill counter with "amount" larger than 1 could not work as intended.

## Fixes
Fix #399 
Fix #312

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested
Instead of doing loops as the one mentioned on the issue #399, there is an option to increase the amount of bestiary kills on the player function _**player:addBestiaryKill()**_
![image](https://user-images.githubusercontent.com/66353315/151188159-91889ee8-f103-45bf-ac1d-9eef0a1f458d.png)

`Example: player:addBestiaryKill("demon", 10) will increase the bestiary kill by 10 in one single line.`

**Test Configuration**:

  - Server Version: Any
  - Client: Any
  - Operating System: Any

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
