### PR TITLE
Docker arm support added

### DIFF
--- a/docker/data/nginx/site.conf
+++ b/docker/data/nginx/site.conf
@@ -1,0 +1,17 @@
+server {
+    index index.php index.html;
+    server_name php-docker.local;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /tmp/web;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass website-php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,10 +9,9 @@ services:
       - 7171:7171
       - 7172:7172
     volumes:
-      - ../data:/otbr/data
+      - ../data/:/otbr/data/
     depends_on:
       - mysql
-      - website
       - login
     links:
       - mysql
@@ -30,19 +29,27 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - db-volume:/var/lib/mysql
+      - db-volume:/var/lib/mysql/
 
-  website:
-    image: webdevops/php-nginx:alpine-php7
+  website-nginx:
+    image: nginx:latest
     restart: unless-stopped
-    environment:
-      - WEB_DOCUMENT_ROOT=/tmp/web/
-      - WEB_DOCUMENT_INDEX=index.php
     ports:
       - 8080:80
     volumes:
-      - ./docker/data/web:/tmp/web
+      - ./data/web/:/tmp/web/
       - ./:/tmp/otserver/
+      - ./data/nginx:/etc/nginx/conf.d/
+    depends_on:
+      - mysql
+      - website-php
+    links:
+      - website-php
+
+  website-php:
+    image: php:7-fpm
+    volumes:
+      - ./data/web/:/tmp/web/
     depends_on:
       - mysql
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,14 +1,16 @@
 # Stage 1: Download all dependencies
 FROM ubuntu:20.04 AS dependencies
 
-RUN apt-get update && apt-get install -y --no-install-recommends cmake
+# Stage 1.1: Setup kitware repository
+## According to: https://apt.kitware.com/
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gpg wget ca-certificates
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN apt-get update && apt-get install kitware-archive-keyring
+RUN rm /usr/share/keyrings/kitware-archive-keyring.gpg
 
-RUN apt-get update && apt-get install -y --no-install-recommends git
-
-RUN apt-get install -y --no-install-recommends \
-	build-essential ca-certificates curl zip unzip tar pkg-config
-
-RUN apt-get install -y --no-install-recommends libluajit-5.1-dev unzip
+# Stage 1.2: Install dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cmake git build-essential curl zip unzip tar pkg-config ninja-build libluajit-5.1-dev
 
 WORKDIR /opt
 RUN git clone https://github.com/microsoft/vcpkg --depth=1
@@ -16,7 +18,7 @@ RUN ./vcpkg/bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg
 COPY vcpkg.json /opt/vcpkg/
-RUN /opt/vcpkg/vcpkg --feature-flags=binarycaching,manifests,versions install
+RUN VCPKG_FORCE_SYSTEM_BINARIES=1 /opt/vcpkg/vcpkg --feature-flags=binarycaching,manifests,versions install
 
 # Stage 2: create build
 FROM dependencies AS build
@@ -27,7 +29,7 @@ COPY src /srv/src
 
 WORKDIR /srv/build
 
-RUN cmake -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake .. && make -j`nproc`
+RUN VCPKG_FORCE_SYSTEM_BINARIES=1 cmake -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake .. && make -j`nproc`
 
 # Stage 3: load data and execute
 FROM build


### PR DESCRIPTION
In docker/server/Dockerfile
tzdata was interactive install and it hangs on geo config # added DEBIAN_FRONTEND=noninteractive
vcpkg install required cmake 3.21 or newer, ubuntu 20.04 has cmake 3.13 # added cmake kitware repository
vcpkg requires VCPKG_FORCE_SYSTEM_BINARIES on arm # added VCPKG_FORCE_SYSTEM_BINARIES to vcpkg install and cmake steps

In docker/docker-compose.yml
webdevops/php-nginx:alpine-php7 doesn't have arm architecture support - replaced with nginx and php images

In docker/data/nginx
added site.conf to provide for nginx container


Tested on Mac with M1 chip.
Server starts properly and is accessible.
Webserver starts properly, MyACC install panel is available.