### PR TITLE
Fix myaac download script

### DIFF
--- a/docker/data/download-myaac.sh
+++ b/docker/data/download-myaac.sh
@@ -4,10 +4,10 @@ wget https://github.com/slawkens/myaac/archive/master.zip -O myaac.zip
 unzip -o myaac.zip -d .
 
 mv myaac-master/* ./web
-rm myaac.zip myaac-master -rf
+rm -rf myaac.zip myaac-master
 
-wget https://github.com/opentibiabr/myaac-tibia12-login/archive/master.zip -O myaac-otbr-plugin.zip
-unzip -o myaac-otbr-plugin.zip -d .
+wget https://github.com/opentibiabr/myaac-tibia12-login/releases/download/2.0/myaac-tibia12-login-v2.0.zip -O myaac-otbr-plugin.zip
+unzip -o myaac-otbr-plugin.zip -d myaac-tibia12-login-master/
 
 cp -r myaac-tibia12-login-master/* ./web
 rm -rf myaac-otbr-plugin.zip myaac-tibia12-login-master


### PR DESCRIPTION
Script had some issues

Fixed rm-rf for zip file and myaac-master dir
Fixed wget from archive/master.zip to released, there is no master branch in opentibiabr/myaac-tibia12-login anymore