### PR TITLE
Fix function name: getAttackSpeed

### DIFF
--- a/data/lib/tables/exercise_training.lua
+++ b/data/lib/tables/exercise_training.lua
@@ -130,6 +130,6 @@ function exerciseEvent(playerId, tilePosition, weaponId, dummyId)
 	end
 
 	local vocation = player:getVocation()
-	onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getBaseAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
+	onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
 	return
 end

--- a/data/scripts/creaturescripts/others/offline_training.lua
+++ b/data/scripts/creaturescripts/others/offline_training.lua
@@ -56,7 +56,7 @@ function offlineTraining.onLogin(player)
 
 	local updateSkill = false
 	if isInArray({SKILL_CLUB, SKILL_SWORD, SKILL_AXE, SKILL_DISTANCE}, offlineTrainingSkill) then
-		local modifier = topVocation:getBaseAttackSpeed() / 1000 / configManager.getFloat(configKeys.RATE_OFFLINE_TRAINING_SPEED)
+		local modifier = topVocation:getAttackSpeed() / 1000 / configManager.getFloat(configKeys.RATE_OFFLINE_TRAINING_SPEED)
 		updateSkill = player:addOfflineTrainingTries(
 					offlineTrainingSkill, (trainingTime / modifier) / (offlineTrainingSkill == SKILL_DISTANCE and 4 or 2))
 	elseif offlineTrainingSkill == SKILL_MAGLEVEL then


### PR DESCRIPTION
Fix function name in exercise training and offline training, from `getBaseAttackSpeed` to `getAttackSpeed`.