### PR TITLE
Remove benchmark details

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2423,7 +2423,6 @@ local function extractValues(tab, ret)
 	end
 end
 
-local benchmark = os.clock()
 local extraction = {}
 extractValues(Storage, extraction) -- Call function
 table.sort(extraction) -- Sort the table
@@ -2436,7 +2435,6 @@ if #extraction > 1 then
 		if extraction[i] == extraction[i+1] then
 			Spdlog.warn(string.format("Duplicate storage value found: %d",
 				extraction[i]))
-			Spdlog.warn(string.format("Processed in %.4f(s)", os.clock() - benchmark))
 		end
 	end
 end


### PR DESCRIPTION
# Description

This was something I have added back then to show the function wasn't heavy and it's already something proven. In one of the commits someone put the processed message inside the condition which removed its purpose and would spam server console with a line that is not relevant as the goal was to show total process time and not individual time for each duplicate found.