### PR TITLE
Fix Event Scheduler

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -218,12 +218,13 @@ globalServerSaveTime = "06:00:00"
 sortLootByChance = false
 
 -- Rates
--- NOTE: rateExp, rateSkill and rateMagic is used as a fallback only
+-- NOTE: rateExp, rateSkill and rateMagic is used when 'rateUseStages = false' - or a fallback only
 -- To configure rates see file data/stages.lua
+rateUseStages = false
 rateExp = 1
-rateSkill = 50
-rateLoot = 3
-rateMagic = 25
+rateSkill = 1
+rateLoot = 1
+rateMagic = 1
 rateSpawn = 1
 
 -- Today regeneration condition over an loop every 1 second,

--- a/data/XML/events.xml
+++ b/data/XML/events.xml
@@ -6,8 +6,8 @@
 		<colors colordark="#235c00" colorlight="#2d7400" />
 		<details displaypriority="6" isseasonal="0" specialevent="0" />
 	</event>
-	<event name="Otservbr example 2" startdate="10/2/2020" enddate="11/7/2020" script="example.lua" >
-		<ingame exprate="50" lootrate="300" spawnrate="150" skillrate="100" />
+	<event name="Otservbr example 2" startdate="2/2/2022" enddate="11/7/2022" script="example.lua" >
+		<ingame exprate="500" lootrate="500" spawnrate="500" skillrate="500" />
 		<description description="Otserver br example 2 description 50% less exp, triple loot !chance!, 50% faster spawn and regular skill" />
 		<colors colordark="#735D10" colorlight="#8B6D05" />
 		<details displaypriority="6" isseasonal="0" specialevent="0" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -693,11 +693,6 @@ function Player:onGainExperience(target, exp, rawExp)
 
 	self:setStoreXpBoost(storeXpBoostAmount)
 
-	-- Exp Boost
-	if (storeXpBoostAmount > 0) then
-		exp = exp + (exp * (storeXpBoostAmount/100))
-	end
-
 	-- Stamina Bonus
 	local staminaBoost = 1
 	if configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
@@ -724,7 +719,7 @@ function Player:onGainExperience(target, exp, rawExp)
 		end
 	end
 
-	return (exp * expStage) * staminaBoost
+	return math.max((exp * expStage + (exp * (storeXpBoostAmount/100))) * staminaBoost)
 end
 
 function Player:onLoseExperience(exp)

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -593,12 +593,20 @@ soulCondition:setTicks(4 * 60 * 1000)
 soulCondition:setParameter(CONDITION_PARAM_SOULGAIN, 1)
 
 local function useStamina(player)
+	if not player then
+		return false
+	end
+
 	local staminaMinutes = player:getStamina()
 	if staminaMinutes == 0 then
 		return
 	end
 
 	local playerId = player:getId()
+	if not playerId then
+		return false
+	end
+
 	local currentTime = os.time()
 	local timePassed = currentTime - nextUseStaminaTime[playerId]
 	if timePassed <= 0 then
@@ -621,13 +629,21 @@ local function useStamina(player)
 	player:setStamina(staminaMinutes)
 end
 
-local function useStaminaXp(player)
+local function useStaminaXpBoost(player)
+	if not player then
+		return false
+	end
+
 	local staminaMinutes = player:getExpBoostStamina() / 60
 	if staminaMinutes == 0 then
 		return
 	end
 
 	local playerId = player:getId()
+	if not playerId then
+		return false
+	end
+
 	local currentTime = os.time()
 	local timePassed = currentTime - nextUseXpStamina[playerId]
 	if timePassed <= 0 then
@@ -648,8 +664,8 @@ local function useStaminaXp(player)
 	player:setExpBoostStamina(staminaMinutes * 60)
 end
 
-function Player:onGainExperience(source, exp, rawExp)
-	if not source or source:isPlayer() then
+function Player:onGainExperience(target, exp, rawExp)
+	if not target or target:isPlayer() then
 		return exp
 	end
 
@@ -661,25 +677,15 @@ function Player:onGainExperience(source, exp, rawExp)
 	end
 
 	-- Experience Stage Multiplier
-	local expStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
-	exp = exp * expStage
-	baseExp = rawExp * expStage
-	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		displayRate = expStage
-	else
-		displayRate = 1
-	end
+	local expStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
 
-	-- Prey system
-	if configManager.getBoolean(configKeys.PREY_ENABLED) then
-		local monsterType = source:getType()
-		if monsterType and monsterType:raceId() > 0 then
-			exp = math.ceil((exp * self:getPreyExperiencePercentage(monsterType:raceId())) / 100)
-		end
+	-- Event scheduler
+	if SCHEDULE_EXP_RATE ~= 100 then
+		expStage = math.max(0, (expStage * SCHEDULE_EXP_RATE)/100)
 	end
 
 	-- Store Bonus
-	useStaminaXp(self) -- Use store boost stamina
+	useStaminaXpBoost(self) -- Use store boost stamina
 
 	local Boost = self:getExpBoostStamina()
 	local stillHasBoost = Boost > 0
@@ -687,36 +693,38 @@ function Player:onGainExperience(source, exp, rawExp)
 
 	self:setStoreXpBoost(storeXpBoostAmount)
 
+	-- Exp Boost
 	if (storeXpBoostAmount > 0) then
-		exp = exp + (baseExp * (storeXpBoostAmount/100)) -- Exp Boost
+		exp = exp + (exp * (storeXpBoostAmount/100))
 	end
 
 	-- Stamina Bonus
+	local staminaBoost = 1
 	if configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
 		useStamina(self)
 		local staminaMinutes = self:getStamina()
-		if staminaMinutes > 2340 and self:isPremium() then
-			exp = exp * 1.5
-			self:setStaminaXpBoost(150)
-		elseif staminaMinutes <= 840 then
-			exp = exp * 0.5 --TODO destroy loot of people with 840- stamina
-			self:setStaminaXpBoost(50)
-		else
-			self:setStaminaXpBoost(100)
-		end
+			if staminaMinutes > 2340 and self:isPremium() then
+				staminaBoost = 1.5
+			elseif staminaMinutes <= 840 then
+				staminaBoost = 0.5 --TODO destroy loot of people with 840- stamina
+			end
+		self:setStaminaXpBoost(staminaBoost * 100)
 	end
 
 	-- Boosted creature
-	if source:getName():lower() == (Game.getBoostedCreature()):lower() then
+	if target:getName():lower() == (Game.getBoostedCreature()):lower() then
 		exp = exp * 2
 	end
 
-	-- Event scheduler
-	if SCHEDULE_EXP_RATE ~= 100 then
-		exp = (exp * SCHEDULE_EXP_RATE)/100
+	-- Prey system
+	if configManager.getBoolean(configKeys.PREY_ENABLED) then
+		local monsterType = target:getType()
+		if monsterType and monsterType:raceId() > 0 then
+			exp = math.ceil((exp * self:getPreyExperiencePercentage(monsterType:raceId())) / 100)
+		end
 	end
-	self:setBaseXpGain(displayRate * 100)
-	return exp
+
+	return (exp * expStage) * staminaBoost
 end
 
 function Player:onLoseExperience(exp)
@@ -733,18 +741,23 @@ function Player:onGainSkillTries(skill, tries)
 	end
 
 	-- Event scheduler skill rate
+	local STAGES_DEFAULT = skillsStages or nil
+	local SKILL_DEFAULT = self:getSkillLevel(skill)
+	local RATE_DEFAULT = configManager.getNumber(configKeys.RATE_SKILL)
+
+	if(skill == SKILL_MAGLEVEL) then -- Magic Level
+		STAGES_DEFAULT = magicLevelStages or nil
+		SKILL_DEFAULT = self:getBaseMagicLevel()
+		RATE_DEFAULT = configManager.getNumber(configKeys.RATE_MAGIC)
+	end
+
+	skillOrMagicRate = getRateFromTable(STAGES_DEFAULT, SKILL_DEFAULT, RATE_DEFAULT)
+
 	if SCHEDULE_SKILL_RATE ~= 100 then
-		tries = (tries * SCHEDULE_SKILL_RATE)/100
+		skillOrMagicRate = math.max(0, (skillOrMagicRate * SCHEDULE_SKILL_RATE) / 100)
 	end
 
-	local skillRate = configManager.getNumber(configKeys.RATE_SKILL)
-	local magicRate = configManager.getNumber(configKeys.RATE_MAGIC)
-
-	if(skill == SKILL_MAGLEVEL) then -- Magic getLevel
-		return tries * getRateFromTable(magicLevelStages, self:getBaseMagicLevel(), magicRate)
-	end
-
-	return tries * getRateFromTable(skillsStages, self:getSkillLevel(skill), skillRate)
+	return tries / 100 * (skillOrMagicRate * 100)
 end
 
 function Player:onRemoveCount(item)

--- a/data/global.lua
+++ b/data/global.lua
@@ -26,6 +26,7 @@ weatherConfig = {
 SCHEDULE_LOOT_RATE = 100
 SCHEDULE_EXP_RATE = 100
 SCHEDULE_SKILL_RATE = 100
+SCHEDULE_SPAWN_RATE = 100
 
 -- MARRY
 PROPOSED_STATUS = 1
@@ -83,23 +84,6 @@ startupGlobalStorages = {
 	GlobalStorage.FerumbrasAscendant.Elements.Third,
 	GlobalStorage.FerumbrasAscendant.Elements.Done
 }
-
-do -- Event Schedule rates
-	local lootRate = Game.getEventSLoot()
-	if lootRate ~= 100 then
-		SCHEDULE_LOOT_RATE = lootRate
-	end
-
-	local expRate = Game.getEventSExp()
-	if expRate ~= 100 then
-		SCHEDULE_EXP_RATE = expRate
-	end
-
-	local skillRate = Game.getEventSSkill()
-	if skillRate ~= 100 then
-		SCHEDULE_SKILL_RATE = skillRate
-	end
-end
 
 table.contains = function(array, value)
 	for _, targetColumn in pairs(array) do

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -396,7 +396,7 @@ function doPlayerAddExp(cid, exp, useMult, ...)
 	end
 
 	if useMult then
-		exp = exp * getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
+		exp = exp * getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
 	end
 	return player:addExperience(exp, ...)
 end

--- a/data/lib/core/functions.lua
+++ b/data/lib/core/functions.lua
@@ -20,7 +20,8 @@ function getFormattedWorldTime()
 end
 
 function getLootRandom()
-	return math.random(0, MAX_LOOTCHANCE) * 100 / (configManager.getNumber(configKeys.RATE_LOOT) * SCHEDULE_LOOT_RATE)
+	local multi = (configManager.getNumber(configKeys.RATE_LOOT) * SCHEDULE_LOOT_RATE)
+	return math.random(0, MAX_LOOTCHANCE) * 100 / math.max(1, multi)
 end
 
 local start = os.time()
@@ -50,9 +51,11 @@ function getJackLastMissionState(player)
 end
 
 function getRateFromTable(t, level, default)
-	for _, rate in ipairs(t) do
-		if level >= rate.minlevel and (not rate.maxlevel or level <= rate.maxlevel) then
-			return rate.multiplier
+	if (t ~= nil) then
+		for _, rate in ipairs(t) do
+			if level >= rate.minlevel and (not rate.maxlevel or level <= rate.maxlevel) then
+				return rate.multiplier
+			end
 		end
 	end
 	return default

--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -232,21 +232,21 @@ DailyReward.retrieveHistoryEntries = function(playerId)
 	return entries
 end
 
-DailyReward.loadDailyReward = function(playerId, source)
+DailyReward.loadDailyReward = function(playerId, target)
 	local player = Player(playerId)
 	if not player then
 		return false
 	end
-	if source ~= 0 then
-		source = REWARD_FROM_SHRINE
+	if target ~= 0 then
+		target = REWARD_FROM_SHRINE
 	else
-		source = REWARD_FROM_PANEL
+		target = REWARD_FROM_PANEL
 	end
 
 	player:sendCollectionResource(ClientPackets.JokerResource, player:getJokerTokens())
 	player:sendCollectionResource(ClientPackets.CollectionResource, player:getCollectionTokens())
 	player:sendDailyReward()
-	player:sendOpenRewardWall(source)
+	player:sendOpenRewardWall(target)
 	player:sendDailyRewardCollectionState(DailyReward.isRewardTaken(player:getId()) and DAILY_REWARD_COLLECTED or DAILY_REWARD_NOTCOLLECTED)
 	return true
 end
@@ -273,8 +273,8 @@ DailyReward.pickedReward = function(playerId)
 	return true
 end
 
-DailyReward.isShrine = function(source)
-	if source ~= 0 then
+DailyReward.isShrine = function(target)
+	if target ~= 0 then
 		return false
 	else
 		return true
@@ -349,9 +349,9 @@ DailyReward.init = function(playerId)
 	player:loadDailyRewardBonuses()
 end
 
-DailyReward.processReward = function(playerId, source)
+DailyReward.processReward = function(playerId, target)
 	DailyReward.pickedReward(playerId)
-	DailyReward.loadDailyReward(playerId, source)
+	DailyReward.loadDailyReward(playerId, target)
 	local player = Player(playerId)
 	if player then
 		player:loadDailyRewardBonuses()
@@ -405,8 +405,8 @@ function Player.selectDailyReward(self, msg)
 		return false
 	end
 
-	local source = msg:getByte() -- 0 -> shrine / 1 -> tibia panel
-	if not DailyReward.isShrine(source) then
+	local target = msg:getByte() -- 0 -> shrine / 1 -> tibia panel
+	if not DailyReward.isShrine(target) then
 		if self:getCollectionTokens() < 1 then
 			self:sendError("You do not have enough collection tokens to proceed.")
 			return false
@@ -477,7 +477,7 @@ function Player.selectDailyReward(self, msg)
 		-- Registering history
 		DailyReward.insertHistory(self:getGuid(), self:getDayStreak(), "Claimed reward no. \z
 			" .. self:getDayStreak() + 1 .. ". Picked items: " .. description)
-		DailyReward.processReward(playerId, source)
+		DailyReward.processReward(playerId, target)
 	end
 
 	local reward = nil
@@ -501,7 +501,7 @@ function Player.selectDailyReward(self, msg)
 		-- end
 		-- DailyReward.insertHistory(self:getGuid(), self:getDayStreak(), "Claimed reward no. \z
 			-- " .. self:getDayStreak() + 1 .. ". Picked reward: " .. description)
-		-- DailyReward.processReward(playerId, source)
+		-- DailyReward.processReward(playerId, target)
 	-- end
 
 	if (dailyTable.type == DAILY_REWARD_TYPE_XP_BOOST) then
@@ -509,14 +509,14 @@ function Player.selectDailyReward(self, msg)
 		self:setStoreXpBoost(50)
 		DailyReward.insertHistory(self:getGuid(), self:getDayStreak(), "Claimed reward no. \z
 			" .. self:getDayStreak() + 1 .. ". Picked reward: XP Bonus for " .. reward .. " minutes.")
-		DailyReward.processReward(playerId, source)
+		DailyReward.processReward(playerId, target)
 	end
 
 	if (dailyTable.type == DAILY_REWARD_TYPE_PREY_REROLL) then
 		self:addPreyCards(reward)
 		DailyReward.insertHistory(self:getGuid(), self:getDayStreak(), "Claimed reward no. \z
 			" .. self:getDayStreak() + 1 .. ". Picked reward: " .. reward .. "x Prey bonus reroll(s)")
-		DailyReward.processReward(playerId, source)
+		DailyReward.processReward(playerId, target)
 	end
 
 	return true

--- a/data/scripts/creaturescripts/others/advance_save.lua
+++ b/data/scripts/creaturescripts/others/advance_save.lua
@@ -5,6 +5,7 @@ local config = {
 }
 
 local advanceSave = CreatureEvent("AdvanceSave")
+
 function advanceSave.onAdvance(player, skill, oldLevel, newLevel)
 	if skill ~= SKILL_LEVEL or newLevel <= oldLevel then
 		return true
@@ -22,6 +23,17 @@ function advanceSave.onAdvance(player, skill, oldLevel, newLevel)
 	if config.save then
 		player:save()
 	end
+
+	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
+		local baseRate = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
+		-- Event scheduler
+		if SCHEDULE_EXP_RATE ~= 100 then
+			baseRate = math.max(0, (baseRate * SCHEDULE_EXP_RATE)/100)
+		end
+		player:setBaseXpGain(baseRate * 100)
+	end
+
 	return true
 end
+
 advanceSave:register()

--- a/data/scripts/creaturescripts/others/login.lua
+++ b/data/scripts/creaturescripts/others/login.lua
@@ -129,9 +129,28 @@ function playerLogin.onLogin(player)
 	if player:getGroup():getId() >= GROUP_TYPE_GAMEMASTER then
 		player:setGhostMode(true)
 	end
+
 	-- Boosted creature
 	player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Today's boosted creature: " .. Game.getBoostedCreature() .. " \
 	Boosted creatures yield more experience points, carry more loot than usual and respawn at a faster rate.")
+
+	if SCHEDULE_SPAWN_RATE ~= 100 then
+		if SCHEDULE_SPAWN_RATE > 100 then
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Spawn Rate Event! Monsters respawn at a faster rate \
+			Happy Hunting!")
+		else
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Spawn Rate Decreased! Monsters respawn at a slower rate.")
+		end
+	end
+
+	if SCHEDULE_LOOT_RATE ~= 100 then
+		if SCHEDULE_LOOT_RATE > 100 then
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Event! Monsters looted at a faster rate \
+			Happy Hunting!")
+		else
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Decreased! looted looted at a slower rate.")
+		end
+	end
 
 	-- Stamina
 	nextUseStaminaTime[playerId] = 1
@@ -178,20 +197,22 @@ function playerLogin.onLogin(player)
 		player:setStorageValue(Storage.combatProtectionStorage, 1)
 		onMovementRemoveProtection(playerId, player:getPosition(), 10)
 	end
-	-- Set Client XP Gain Rate
-	local baseExp = 100
+
+	-- Set Client XP Gain Rate --
+	local rateExp = 1
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		baseExp = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
+		rateExp = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
+
+		if SCHEDULE_EXP_RATE ~= 100 then
+			rateExp = math.max(0, (rateExp * SCHEDULE_EXP_RATE)/100)
+		end
 	end
 
 	local staminaMinutes = player:getStamina()
-	local doubleExp = false --Can change to true if you have double exp on the server
 	local staminaBonus = (staminaMinutes > 2340) and 150 or ((staminaMinutes < 840) and 50 or 100)
-	if doubleExp then
-		baseExp = baseExp * 2
-	end
+
 	player:setStaminaXpBoost(staminaBonus)
-	player:setBaseXpGain(baseExp)
+	player:setBaseXpGain(rateExp * 100)
 
 	if onExerciseTraining[player:getId()] then -- onLogin & onLogout
 		stopEvent(onExerciseTraining[player:getId()].event)

--- a/data/scripts/creaturescripts/others/login.lua
+++ b/data/scripts/creaturescripts/others/login.lua
@@ -134,6 +134,15 @@ function playerLogin.onLogin(player)
 	player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Today's boosted creature: " .. Game.getBoostedCreature() .. " \
 	Boosted creatures yield more experience points, carry more loot than usual and respawn at a faster rate.")
 
+	if SCHEDULE_EXP_RATE ~= 100 then
+		if SCHEDULE_EXP_RATE > 100 then
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Event! Monsters exp at a faster rate \
+			Happy Hunting!")
+		else
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Decreased! Monsters exp at a slower rate.")
+		end
+	end
+
 	if SCHEDULE_SPAWN_RATE ~= 100 then
 		if SCHEDULE_SPAWN_RATE > 100 then
 			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Spawn Rate Event! Monsters respawn at a faster rate \

--- a/data/scripts/creaturescripts/others/login.lua
+++ b/data/scripts/creaturescripts/others/login.lua
@@ -136,10 +136,10 @@ function playerLogin.onLogin(player)
 
 	if SCHEDULE_EXP_RATE ~= 100 then
 		if SCHEDULE_EXP_RATE > 100 then
-			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Event! Monsters exp at a faster rate \
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Event! Monsters yield more experience points than usual \
 			Happy Hunting!")
 		else
-			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Decreased! Monsters exp at a slower rate.")
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Exp Rate Decreased! Monsters yield less experience points than usual.")
 		end
 	end
 
@@ -154,10 +154,19 @@ function playerLogin.onLogin(player)
 
 	if SCHEDULE_LOOT_RATE ~= 100 then
 		if SCHEDULE_LOOT_RATE > 100 then
-			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Event! Monsters looted at a faster rate \
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Event! Monsters carry more loot than usual \
 			Happy Hunting!")
 		else
-			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Decreased! looted looted at a slower rate.")
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Loot Rate Decreased! Monsters carry less loot than usual.")
+		end
+	end
+
+	if SCHEDULE_SKILL_RATE ~= 100 then
+		if SCHEDULE_SKILL_RATE > 100 then
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Skill Rate Event! Your skills progresses at a higher rate \
+			Happy Hunting!")
+		else
+			player:sendTextMessage(MESSAGE_BOOSTED_CREATURE, "Skill Rate Decreased! Your skills progresses at a lower rate.")
 		end
 	end
 

--- a/data/scripts/globalevents/others/startup.lua
+++ b/data/scripts/globalevents/others/startup.lua
@@ -122,10 +122,36 @@ function serverstartup.onStartup()
 		result.free(resultId)
 	end
 
-	-- Client XP Display Mode
+	do -- Event Schedule rates
+		local lootRate = EventsScheduler.getEventSLoot()
+		if lootRate ~= 100 then
+			SCHEDULE_LOOT_RATE = lootRate
+		end
+
+		local expRate = EventsScheduler.getEventSExp()
+		if expRate ~= 100 then
+			SCHEDULE_EXP_RATE = expRate
+		end
+
+		local skillRate = EventsScheduler.getEventSSkill()
+		if skillRate ~= 100 then
+			SCHEDULE_SKILL_RATE = skillRate
+		end
+
+		local spawnRate = EventsScheduler.getSpawnMonsterSchedule()
+		if spawnRate ~= 100 then
+			SCHEDULE_SPAWN_RATE = spawnRate
+		end
+
+		if expRate ~= 100 or lootRate ~= 100 or spawnRate ~= 100 or skillRate ~= 100 then
+		Spdlog.info("Events: " .. "Exp: " .. expRate .. "%, " .. "loot: " .. lootRate .. "%, " .. "Spawn: " .. spawnRate .. "%, " .. "Skill: ".. skillRate .."%")
+		end
+	end
+
+    -- Client XP Display Mode
 	-- 0 = ignore exp rate /stage
 	-- 1 = include exp rate / stage
-	Game.setStorageValue(GlobalStorage.XpDisplayMode, 0)
+	Game.setStorageValue(GlobalStorage.XpDisplayMode, 1)
 
 	-- Hireling System
 	HirelingsInit()

--- a/data/scripts/talkactions/player/server_info.lua
+++ b/data/scripts/talkactions/player/server_info.lua
@@ -3,7 +3,7 @@ local serverInfo = TalkAction("!serverinfo")
 function serverInfo.onSay(player, words, param)
 	local configRateSkill =  configManager.getNumber(configKeys.RATE_SKILL)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Server Info:"
-	.. "\nExp rate: " .. getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
+	.. "\nExp rate: " .. getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
 	.. "\nSword Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_SWORD), configRateSkill)
 	.. "\nClub Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_CLUB), configRateSkill)
 	.. "\nAxe Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_AXE), configRateSkill)


### PR DESCRIPTION
## Behaviour
### **Actual**

This PR works directly with: https://github.com/opentibiabr/canary/pull/239

## **Fix:**
- [x]  #461 

On login you have one "XP Gain Rate", when you get experience this value changed.
Event schedule only display info, but doesn't work.

### **Expected**
[Formulae Tibia Wiki](https://tibia.fandom.com/wiki/Formulae)

- [x] Display correctely "XP Gain Rate".
- [x]  Event Schedule server-side.
- [x]  Exercise Training get bonus of events.

## Fixes
### **global.lua & statup.lua**
- moved form ```global.lua -> globalevents\others\startup.lua``` all events rates variables.
```getEventSSkill, getEventSExp and getEventSLoot``` now load after events module.
- set ```GlobalStorage.XpDisplayMode -> 1```

## player.lua
- Fixed ```onGainExperience```; Added ```preyBonus & staminaBoost``` variable.
now use simple rule of 3...
Rat: if 5 exp --- 100% | ? exp --- 150% so... 5 / 100 * 150 = 7(BaseXpGain + etc) see [Rat](https://www.tibiawiki.com.br/wiki/Rat)
## lib\core\functions.lua
- ```getLootRandom``` approximate to real tibia.
- ```getRateFromTable``` when doesn't have stages, return default.

## configmanager.cpp & configmanager.h
- added ```RATE_USE_STAGES``` boolean config ```rateUseStages = true```.
-fixed ```RATE_EXPERIENCE```.
- set base rates to 1.

## creaturescript\others\login.lua
- fixed ```setBaseXpGain```, now work with events too.

## spawn.cpp & spawn.h
- fixed interval spawn time.
- when the spawn time is less than ```MINSPAWN_INTERVAL```, addMonster with min value.
- now ```interval``` to ```30000```, less check time.

## game.cpp, scripts\luascript.cpp & protocolstatus.cpp
- some fixes

## otserv.cpp & config.lua.dist
- On/Off stagesExp(def: true).
- set rates to 1
## events.xml
- changed date for test.
- can use exprate="0", with any argument (this reduce the rate to 0, but not the exp).
NOTE: exprate, lootrate, spawnrate or skillrate in 100, it's default value.
## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested
[Rat](https://www.tibiawiki.com.br/wiki/Rat) Test 1: without event, rateExp x1 + stamina : 150% = 7.5
 [Rat](https://www.tibiawiki.com.br/wiki/Rat) Test 2: with event +100%, rateExp 100% + prey 40% + store 50% + stamina x1.5 : 435% = 21,75

**Test Configuration**:

Server Version: 
Client: Client 12.85
Operating System: Windows 11

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (i don't see)
- [ ] I have added tests that prove my fix is effective or that my feature works