### PR TITLE
[ItemParse] - Fix life and mana leech amount/chance attribute

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -47344,6 +47344,8 @@
 	<item id="30399" name="cobra wand">
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="magicpoints" value="2"/>
+		<attribute key="criticalhitdamage" value="35"/>
+		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="1900"/>
 		<attribute key="upgradeclassification" value="4"/>
@@ -47356,6 +47358,8 @@
 	<item id="30400" name="cobra rod">
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="magicpoints" value="2"/>
+		<attribute key="lifeleechamount" value="18"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="range" value="5"/>
 		<attribute key="weight" value="2500"/>
 		<attribute key="upgradeclassification" value="4"/>
@@ -52192,10 +52196,10 @@
 		<attribute key="weaponType" value="sword"/>
 		<attribute key="loottype" value="sword"/>
 		<attribute key="elementdeath" value="45"/>
-		<attribute key="skillmanaamount" value="3"/>
-		<attribute key="skillmanachance" value="100"/>
-		<attribute key="skilllifeamount" value="5"/>
-		<attribute key="skilllifechance" value="100"/>
+		<attribute key="manaleechamount" value="3"/>
+		<attribute key="manaleechchance" value="100"/>
+		<attribute key="lifeleechamount" value="5"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="skillsword" value="5"/>
 		<attribute key="attack" value="7"/>
 		<attribute key="extradef" value="3"/>
@@ -52234,10 +52238,10 @@
 		<attribute key="weaponType" value="axe"/>
 		<attribute key="loottype" value="axe"/>
 		<attribute key="elementdeath" value="45"/>
-		<attribute key="skillmanaamount" value="3"/>
-		<attribute key="skillmanachance" value="100"/>
-		<attribute key="skilllifeamount" value="5"/>
-		<attribute key="skilllifechance" value="100"/>
+		<attribute key="manaleechamount" value="3"/>
+		<attribute key="manaleechchance" value="100"/>
+		<attribute key="lifeleechamount" value="5"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="attack" value="7"/>
 		<attribute key="extradef" value="3"/>
@@ -52276,10 +52280,10 @@
 		<attribute key="weaponType" value="club"/>
 		<attribute key="loottype" value="club"/>
 		<attribute key="elementice" value="46"/>
-		<attribute key="skillmanaamount" value="3"/>
-		<attribute key="skillmanachance" value="100"/>
-		<attribute key="skilllifeamount" value="5"/>
-		<attribute key="skilllifechance" value="100"/>
+		<attribute key="manaleechamount" value="3"/>
+		<attribute key="manaleechchance" value="100"/>
+		<attribute key="lifeleechamount" value="5"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="skillclub" value="5"/>
 		<attribute key="attack" value="6"/>
 		<attribute key="extradef" value="3"/>
@@ -52341,6 +52345,8 @@
 		<attribute key="loottype" value="distance"/>
 		<attribute key="absorbpercentdeath" value="7"/>
 		<attribute key="skilldist" value="4"/>
+		<attribute key="criticalhitdamage" value="10"/>
+		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="hitchance" value="6"/>
 		<attribute key="range" value="6"/>
 		<attribute key="attack" value="9"/>
@@ -52377,10 +52383,10 @@
 		<attribute key="loottype" value="wand"/>
 		<attribute key="absorbpercentice" value="12"/>
 		<attribute key="magicpoints" value="5"/>
-		<attribute key="skillmanaamount" value="3"/>
-		<attribute key="skillmanachance" value="100"/>
-		<attribute key="skilllifeamount" value="5"/>
-		<attribute key="skilllifechance" value="100"/>
+		<attribute key="manaleechamount" value="3"/>
+		<attribute key="manaleechchance" value="100"/>
+		<attribute key="lifeleechamount" value="5"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="range" value="6"/>
 		<attribute key="weight" value="2500"/>
 		<attribute key="upgradeclassification" value="4"/>
@@ -52758,8 +52764,8 @@
 		<attribute key="shootType" value="smallice"/>
 		<attribute key="loottype" value="wand"/>
 		<attribute key="magicpoints" value="2"/>
-		<attribute key="skilllifeamount" value="18"/>
-		<attribute key="skilllifechance" value="100"/>
+		<attribute key="lifeleechamount" value="18"/>
+		<attribute key="lifeleechchance" value="100"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="2100"/>
 		<attribute key="upgradeclassification" value="4"/>


### PR DESCRIPTION
# Description

- This PR is a complementation of this Canary PR https://github.com/opentibiabr/canary/pull/254
- This is a fix to correct the item tags of mana leech and life leech items attributes. 
- Extra: added attributes missing on some soulwar weapons.

## Behaviour
### **Actual**

The items with attributes life leech and mana leech don't work.

### **Expected**

Mana leech and life leech attributes working as expected.

## Fixes

Resolve #429 

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Test any weapon with Life leech and Mana leech attribute

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
