### PR TITLE
Fix minotaur cult monsters

### DIFF
--- a/data/monster/humanoids/minotaur_cult_follower.lua
+++ b/data/monster/humanoids/minotaur_cult_follower.lua
@@ -104,14 +104,14 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -150},
-	{name ="combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -180, maxDamage = -250, range = 7, effect = CONST_ME_EXPLOSIONAREA, target = true}
+	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -240},
+	{name ="combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -110, maxDamage = -210, radius = 3, effect = CONST_ME_GROUNDSHAKER, target = false}
 }
 
 monster.defenses = {
 	defense = 25,
 	armor = 25,
-	{name ="combat", interval = 1000, chance = 20, type = COMBAT_HEALING, minDamage = 200, maxDamage = 450, effect = CONST_ME_MAGIC_BLUE, target = false}
+	{name ="combat", interval = 1000, chance = 20, type = COMBAT_HEALING, minDamage = 100, maxDamage = 200, effect = CONST_ME_MAGIC_BLUE, target = false}
 }
 
 monster.elements = {

--- a/data/monster/humanoids/minotaur_cult_prophet.lua
+++ b/data/monster/humanoids/minotaur_cult_prophet.lua
@@ -110,7 +110,7 @@ monster.attacks = {
 monster.defenses = {
 	defense = 15,
 	armor = 15,
-	{name ="minotaur_cult_prophet_mass_healing", interval = 2000, chance = 20, target = false}
+	{name ="Minotaur Cult Prophet Mass Healing", interval = 2000, chance = 20, target = false}
 }
 
 monster.elements = {

--- a/data/monster/humanoids/minotaur_cult_prophet.lua
+++ b/data/monster/humanoids/minotaur_cult_prophet.lua
@@ -1,46 +1,6 @@
 local mType = Game.createMonsterType("Minotaur Cult Prophet")
 local monster = {}
 
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
-combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
-
-local area = createCombatArea(AREA_CIRCLE5X5)
-combat:setArea(area)
-
-function spellCallback(param)
-	local tile = Tile(Position(param.pos))
-	if tile then
-		if tile:getTopCreature() and tile:getTopCreature():isMonster() then
-			tile:getTopCreature():addHealth(math.random(200, 350))
-		end
-	end
-end
-
-function onTargetTile(cid, pos)
-	local param = {}
-	param.cid = cid
-	param.pos = pos
-	param.count = 0
-	spellCallback(param)
-end
-
-setCombatCallback(combat, CALLBACK_PARAM_TARGETTILE, "onTargetTile")
-
-local spell = Spell("instant")
-
-function spell.onCastSpell(creature, var)
-	return combat:execute(creature, var)
-end
-
-spell:name("minotaurcultprophetheal")
-spell:words("###404")
-spell:blockWalls(true)
-spell:needLearn(true)
-spell:register()
-
-
 monster.description = "a minotaur cult prophet"
 monster.experience = 1100
 monster.outfit = {
@@ -52,8 +12,6 @@ monster.outfit = {
 	lookAddons = 0,
 	lookMount = 0
 }
-
-monster.enemyFactions = {FACTION_PLAYER}
 
 monster.raceId = 1509
 monster.Bestiary = {
@@ -152,7 +110,7 @@ monster.attacks = {
 monster.defenses = {
 	defense = 15,
 	armor = 15,
-	{name ="minotaurcultprophetheal", interval = 2000, radius = 6, chance = 20, target = false}
+	{name ="minotaur_cult_prophet_mass_healing", interval = 2000, chance = 20, target = false}
 }
 
 monster.elements = {

--- a/data/monster/humanoids/minotaur_cult_prophet.lua
+++ b/data/monster/humanoids/minotaur_cult_prophet.lua
@@ -1,6 +1,46 @@
 local mType = Game.createMonsterType("Minotaur Cult Prophet")
 local monster = {}
 
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
+combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
+
+local area = createCombatArea(AREA_CIRCLE5X5)
+combat:setArea(area)
+
+function spellCallback(param)
+	local tile = Tile(Position(param.pos))
+	if tile then
+		if tile:getTopCreature() and tile:getTopCreature():isMonster() then
+			tile:getTopCreature():addHealth(math.random(200, 350))
+		end
+	end
+end
+
+function onTargetTile(cid, pos)
+	local param = {}
+	param.cid = cid
+	param.pos = pos
+	param.count = 0
+	spellCallback(param)
+end
+
+setCombatCallback(combat, CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("minotaurcultprophetheal")
+spell:words("###404")
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:register()
+
+
 monster.description = "a minotaur cult prophet"
 monster.experience = 1100
 monster.outfit = {
@@ -12,6 +52,8 @@ monster.outfit = {
 	lookAddons = 0,
 	lookMount = 0
 }
+
+monster.enemyFactions = {FACTION_PLAYER}
 
 monster.raceId = 1509
 monster.Bestiary = {
@@ -102,28 +144,28 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100},
-	{name ="combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -20, maxDamage = -350, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = false},
-	{name ="combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -300, range = 7, radius = 1, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true}
+	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -240},
+	{name ="combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -200, maxDamage = -350, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true},
+	{name ="combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -350, range = 7, radius = 1, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true}
 }
 
 monster.defenses = {
 	defense = 15,
 	armor = 15,
-	{name ="heal monster", interval = 2000, chance = 20, effect = CONST_ME_MAGIC_BLUE, target = false}
+	{name ="minotaurcultprophetheal", interval = 2000, radius = 6, chance = 20, target = false}
 }
 
 monster.elements = {
 	{type = COMBAT_PHYSICALDAMAGE, percent = 0},
-	{type = COMBAT_ENERGYDAMAGE, percent = 0},
-	{type = COMBAT_EARTHDAMAGE, percent = 0},
+	{type = COMBAT_ENERGYDAMAGE, percent = 20},
+	{type = COMBAT_EARTHDAMAGE, percent = 20},
 	{type = COMBAT_FIREDAMAGE, percent = 0},
 	{type = COMBAT_LIFEDRAIN, percent = 0},
 	{type = COMBAT_MANADRAIN, percent = 0},
 	{type = COMBAT_DROWNDAMAGE, percent = 0},
-	{type = COMBAT_ICEDAMAGE, percent = 0},
-	{type = COMBAT_HOLYDAMAGE , percent = 0},
-	{type = COMBAT_DEATHDAMAGE , percent = 0}
+	{type = COMBAT_ICEDAMAGE, percent = -10},
+	{type = COMBAT_HOLYDAMAGE , percent = 10},
+	{type = COMBAT_DEATHDAMAGE , percent = -5}
 }
 
 monster.immunities = {

--- a/data/monster/humanoids/minotaur_cult_zealot.lua
+++ b/data/monster/humanoids/minotaur_cult_zealot.lua
@@ -99,9 +99,8 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200},
-	{name ="combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -180, maxDamage = -230, range = 7, shootEffect = CONST_ANI_WHIRLWINDAXE, target = true},
-	{name ="combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -180, maxDamage = -250, range = 7, effect = CONST_ME_EXPLOSIONHIT, target = true}
+	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -340},
+	{name ="combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -90, maxDamage = -320, range = 7, shootEffect = CONST_ANI_WHIRLWINDAXE, target = true}
 }
 
 monster.defenses = {
@@ -113,13 +112,13 @@ monster.elements = {
 	{type = COMBAT_PHYSICALDAMAGE, percent = 0},
 	{type = COMBAT_ENERGYDAMAGE, percent = 0},
 	{type = COMBAT_EARTHDAMAGE, percent = 0},
-	{type = COMBAT_FIREDAMAGE, percent = 0},
+	{type = COMBAT_FIREDAMAGE, percent = 20},
 	{type = COMBAT_LIFEDRAIN, percent = 0},
 	{type = COMBAT_MANADRAIN, percent = 0},
 	{type = COMBAT_DROWNDAMAGE, percent = 0},
-	{type = COMBAT_ICEDAMAGE, percent = 0},
-	{type = COMBAT_HOLYDAMAGE , percent = 0},
-	{type = COMBAT_DEATHDAMAGE , percent = 0}
+	{type = COMBAT_ICEDAMAGE, percent = -10},
+	{type = COMBAT_HOLYDAMAGE , percent = 10},
+	{type = COMBAT_DEATHDAMAGE , percent = -10}
 }
 
 monster.immunities = {

--- a/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
+++ b/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
@@ -7,35 +7,30 @@ local monsters = {
 	"minotaur cult zealot",
 }
 
-local area = createCombatArea(AREA_CIRCLE3X3)
-combat:setArea(area)
-
-function onTargetTile(cid, pos)
+function onTargetTile(creature, pos)
 	local tile = Tile(pos)
-    	if tile then
-    		local target = tile:getTopCreature()
-    		if target and target ~= cid then
-    			targetName = target:getName():lower()
-    			casterName = cid:getName():lower()
-    			if table.contains(monsters, targetName) then
-    			local healingValue = math.random(200, 350)
-    				target:addHealth(healingValue)
-    			end
-    		end
-    	end
-    return true
+	if tile then
+		local target = tile:getTopCreature()
+		if target and target ~= creature then
+			if table.contains(monsters, target:getName():lower()) then
+				target:addHealth(math.random(200, 350))
+			end
+		end
+	end
+	return true
 end
 
-setCombatCallback(combat, CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+combat:setArea(createCombatArea(AREA_CIRCLE3X3))
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
 
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, variant)
-    return combat:execute(creature, variant)
+	return combat:execute(creature, variant)
 end
 
-spell:name("minotaur_cult_prophet_mass_healing")
-spell:words("###404")
+spell:name("Minotaur Cult Prophet Mass Healing")
+spell:words("##488")
 spell:blockWalls(true)
 spell:needLearn(true)
 spell:isAggressive(false)

--- a/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
+++ b/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
@@ -1,0 +1,42 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
+
+local monsters = {
+	"minotaur cult prophet",
+	"minotaur cult follower",
+	"minotaur cult zealot",
+}
+
+local area = createCombatArea(AREA_CIRCLE3X3)
+combat:setArea(area)
+
+function onTargetTile(cid, pos)
+	local tile = Tile(pos)
+    	if tile then
+    		local target = tile:getTopCreature()
+    		if target and target ~= cid then
+    			targetName = target:getName():lower()
+    			casterName = cid:getName():lower()
+    			if table.contains(monsters, targetName) then
+    			local healingValue = math.random(200, 350)
+    				target:addHealth(healingValue)
+    			end
+    		end
+    	end
+    return true
+end
+
+setCombatCallback(combat, CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, variant)
+    return combat:execute(creature, variant)
+end
+
+spell:name("minotaur_cult_prophet_mass_healing")
+spell:words("###404")
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:isAggressive(false)
+spell:register()

--- a/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
+++ b/data/scripts/spells/monster/minotaur_cult_prophet_mass_healing.lua
@@ -7,13 +7,15 @@ local monsters = {
 	"minotaur cult zealot",
 }
 
+local healingValue = math.random(200, 350)
+
 function onTargetTile(creature, pos)
 	local tile = Tile(pos)
 	if tile then
 		local target = tile:getTopCreature()
 		if target and target ~= creature then
 			if table.contains(monsters, target:getName():lower()) then
-				target:addHealth(math.random(200, 350))
+				target:addHealth(healingValue)
 			end
 		end
 	end
@@ -26,6 +28,7 @@ combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, variant)
+	creature:addHealth(healingValue) -- otherwise minotaur cult didnt heal itself, only allies
 	return combat:execute(creature, variant)
 end
 


### PR DESCRIPTION
# Description

- This PR contains fixes for minotaur cult monsters. 
- added base version for "exura gran mas res" (based on CALLBACK_PARAM_TARGETTILE), healing nearby monsters which can be reused for Orc Cult Priest
- my favorite hunting spot, decided that this one will be the first one I fix

## Behaviour
### **Actual**

MinotaurCult Follower, MinotaurCult Zealot, and MinotaurCult Prophet resistances & spells were incorrect

### **Expected**

MinotaurCult Follower, MinotaurCult Zealot, and MinotaurCult Prophet resistances & spells should have correct values

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] resistances & spell damage values were taken from https://tibiopedia.pl/ 
  - [X] watched a few youtube videos to ensure I've used correct spell animations. 
  - [X] healing values for Minotaur Cult Follower were taken from https://www.tibiawiki.com.br/wiki/Minotaur_Cult_Follower

## Checklist

  - [x] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented on my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
