### PR TITLE
[Fix] talkDelay from npcs

### DIFF
--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -583,8 +583,9 @@ if NpcHandler == nil then
 			if delay ~= nil and delay > 1 then
 				self.talkDelay = delay
 			end
-			print(self.talkDelay)
-			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay),
+			-- Interval for sending subsequent messages from the first
+			local remainingMessagesInterval = 1000
+			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay + remainingMessagesInterval),
                              self.eventDelayedSay[playerId][messagesTable], playerUniqueId)
 			ret[#ret + 1] = self.eventDelayedSay[playerId][messagesTable]
 		end

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -66,8 +66,8 @@ if NpcHandler == nil then
 	NpcHandler = {
 		keywordHandler = nil,
 		talkStart = nil,
-		talkDelayTime = 1, -- Seconds to delay outgoing messages.
 		talkDelay = 1000, -- Delay from each messages
+		talkDelayTimeFromEachMessage = 1, -- Seconds to delay outgoing messages
 		callbackFunctions = nil,
 		modules = nil,
 		eventSay = nil,
@@ -79,10 +79,6 @@ if NpcHandler == nil then
 			[MESSAGE_GREET] = "Greetings, |PLAYERNAME|.",
 			[MESSAGE_FAREWELL] = "Good bye, |PLAYERNAME|.",
 			[MESSAGE_BUY] = "Do you want to buy |ITEMCOUNT| |ITEMNAME| for |TOTALCOST| gold coins?",
-			--[EMPTY] = "EMPTY",
-			--[EMPTY] = "EMPTY",
-			--[EMPTY] = "EMPTY",
-			--[EMPTY] = "EMPTY",
 			[MESSAGE_MISSINGMONEY] = "You don't have enough money.",
 			[MESSAGE_NEEDMONEY] = "You don't have enough money.",
 			[MESSAGE_MISSINGITEM] = "You don't have so many.",
@@ -586,9 +582,8 @@ if NpcHandler == nil then
 			if delay ~= nil and delay > 1 then
 				self.talkDelay = delay
 			end
-			-- Interval for sending subsequent messages from the first
-			local remainingMessagesInterval = 1000
-			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay + remainingMessagesInterval),
+			-- The "self.talkDelayTimeFromEachMessage * 1000" = Interval for sending subsequent messages from the first
+			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay + self.talkDelayTimeFromEachMessage * 1000),
                              self.eventDelayedSay[playerId][messagesTable], playerUniqueId)
 			ret[#ret + 1] = self.eventDelayedSay[playerId][messagesTable]
 		end
@@ -638,7 +633,7 @@ if NpcHandler == nil then
 				npc:say(self:parseMessage(messageDelayed, parseInfo),
                         textType or TALKTYPE_PRIVATE_NP, false, focusPlayer, npc:getPosition())
 			end
-		end, self.talkDelayTime * 1000, npcId, message, focusId)
+		end, self.talkDelayTimeFromEachMessage * 1000, npcId, message, focusId)
 	end
 
 	-- sendMessages(msg, messagesTable, npc, player, useDelay(true or false), delay)

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -314,9 +314,12 @@ if NpcHandler == nil then
 	end
 
 	-- Changes the default response message with the specified id to newMessage
-	function NpcHandler:setMessage(id, newMessage)
+	function NpcHandler:setMessage(id, newMessage, delay)
 		if self.messages ~= nil then
 			self.messages[id] = newMessage
+			if delay ~= nil and delay > 1 then
+				self.talkDelay = delay
+			end
 		end
 	end
 

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -67,7 +67,7 @@ if NpcHandler == nil then
 		keywordHandler = nil,
 		talkStart = nil,
 		talkDelay = 1000, -- Delay from each messages
-		talkDelayTimeFromEachMessage = 1, -- Seconds to delay outgoing messages
+		talkDelayTimeForOutgoingMessages = 1, -- Seconds to delay outgoing messages
 		callbackFunctions = nil,
 		modules = nil,
 		eventSay = nil,
@@ -582,8 +582,8 @@ if NpcHandler == nil then
 			if delay ~= nil and delay > 1 then
 				self.talkDelay = delay
 			end
-			-- The "self.talkDelayTimeFromEachMessage * 1000" = Interval for sending subsequent messages from the first
-			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay + self.talkDelayTimeFromEachMessage * 1000),
+			-- The "self.talkDelayTimeForOutgoingMessages * 1000" = Interval for sending subsequent messages from the first
+			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay + self.talkDelayTimeForOutgoingMessages * 1000),
                              self.eventDelayedSay[playerId][messagesTable], playerUniqueId)
 			ret[#ret + 1] = self.eventDelayedSay[playerId][messagesTable]
 		end
@@ -633,7 +633,7 @@ if NpcHandler == nil then
 				npc:say(self:parseMessage(messageDelayed, parseInfo),
                         textType or TALKTYPE_PRIVATE_NP, false, focusPlayer, npc:getPosition())
 			end
-		end, self.talkDelayTimeFromEachMessage * 1000, npcId, message, focusId)
+		end, self.talkDelayTimeForOutgoingMessages * 1000, npcId, message, focusId)
 	end
 
 	-- sendMessages(msg, messagesTable, npc, player, useDelay(true or false), delay)

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -594,7 +594,7 @@ if NpcHandler == nil then
 
 	-- Makes the npc represented by this instance of NpcHandler say something.
 	-- This implements the currently set type of talkdelay.
-	-- Delay 
+	-- The "delay" variable sets the delay for the interval between messages
 	function NpcHandler:say(message, npc, player, delay, textType)
 		local playerId = player:getId()
 		if type(message) == "table" then

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -67,7 +67,7 @@ if NpcHandler == nil then
 		keywordHandler = nil,
 		talkStart = nil,
 		talkDelayTime = 1, -- Seconds to delay outgoing messages.
-		talkDelay = nil,
+		talkDelay = 1000, -- Delay from each messages
 		callbackFunctions = nil,
 		modules = nil,
 		eventSay = nil,
@@ -109,7 +109,6 @@ if NpcHandler == nil then
 		obj.eventDelayedSay = {}
 		obj.topic = {}
 		obj.talkStart = {}
-		obj.talkDelay = {}
 		obj.keywordHandler = keywordHandler
 		obj.messages = {}
 
@@ -352,7 +351,7 @@ if NpcHandler == nil then
 				local parseInfo = { [TAG_PLAYERNAME] = playerName }
 				self:resetNpc(player)
 				msg = self:parseMessage(msg, parseInfo)
-				self:say(msg, npc, player, true)
+				self:say(msg, npc, player)
 				self:removeInteraction(npc, player)
 			end
 		end
@@ -371,7 +370,7 @@ if NpcHandler == nil then
 				local playerName = player:getName() or -1
 				local parseInfo = { [TAG_PLAYERNAME] = playerName }
 				msg = self:parseMessage(msg, parseInfo)
-				self:say(msg, npc, player, true)
+				self:say(msg, npc, player)
 			end
 		end
 		self:setInteraction(npc, player)
@@ -579,17 +578,22 @@ if NpcHandler == nil then
 
 		self.eventDelayedSay[playerId] = {}
 		local ret = {}
-		for aux = 1, #msgs do
-			self.eventDelayedSay[playerId][aux] = {}
-			npc:sayWithDelay(npcUniqueId, msgs[aux], TALKTYPE_PRIVATE_NP, ((aux-1) * (delay or 4000)),
-                             self.eventDelayedSay[playerId][aux], playerUniqueId)
-			ret[#ret + 1] = self.eventDelayedSay[playerId][aux]
+		for messagesTable, messageString in pairs(msgs) do
+			self.eventDelayedSay[playerId][messagesTable] = {}
+			if delay ~= nil and delay > 1 then
+				self.talkDelay = delay
+			end
+			print(self.talkDelay)
+			npc:sayWithDelay(npcUniqueId, msgs[messagesTable], TALKTYPE_PRIVATE_NP, ((messagesTable-1) * self.talkDelay),
+                             self.eventDelayedSay[playerId][messagesTable], playerUniqueId)
+			ret[#ret + 1] = self.eventDelayedSay[playerId][messagesTable]
 		end
 		return(ret)
 	end
 
 	-- Makes the npc represented by this instance of NpcHandler say something.
-	--	This implements the currently set type of talkdelay.
+	-- This implements the currently set type of talkdelay.
+	-- Delay 
 	function NpcHandler:say(message, npc, player, delay, textType)
 		local playerId = player:getId()
 		if type(message) == "table" then

--- a/data/npclua/a_dragon_mother.lua
+++ b/data/npclua/a_dragon_mother.lua
@@ -77,10 +77,8 @@ local function creatureSayCallback(npc, creature, type, message)
 	end
 
 	if MsgContains(message, "help") then
-		npcHandler:say({
-			"I'm aware what you are looking for. Usually I would rather devour you, but due to unfortunate circumstances, I need your {assistance}.",
-			"Test message"
-		}, npc, creature, 5000)
+		npcHandler:say(
+			"I'm aware what you are looking for. Usually I would rather devour you, but due to unfortunate circumstances, I need your {assistance}.", npc, creature, 5000)
 		npcHandler:setTopic(playerId, 2)
 	elseif MsgContains(message, "assistance") then
 		if npcHandler:getTopic(playerId) == 2 then

--- a/data/npclua/a_dragon_mother.lua
+++ b/data/npclua/a_dragon_mother.lua
@@ -79,7 +79,8 @@ local function creatureSayCallback(npc, creature, type, message)
 	if MsgContains(message, "help") then
 		npcHandler:say({
 			"I'm aware what you are looking for. Usually I would rather devour you, but due to unfortunate circumstances, I need your {assistance}.",
-		}, npc, creature)
+			"Test message"
+		}, npc, creature, 5000)
 		npcHandler:setTopic(playerId, 2)
 	elseif MsgContains(message, "assistance") then
 		if npcHandler:getTopic(playerId) == 2 then

--- a/data/npclua/a_dragon_mother.lua
+++ b/data/npclua/a_dragon_mother.lua
@@ -78,7 +78,7 @@ local function creatureSayCallback(npc, creature, type, message)
 
 	if MsgContains(message, "help") then
 		npcHandler:say(
-			"I'm aware what you are looking for. Usually I would rather devour you, but due to unfortunate circumstances, I need your {assistance}.", npc, creature, 5000)
+			"I'm aware what you are looking for. Usually I would rather devour you, but due to unfortunate circumstances, I need your {assistance}.", npc, creature)
 		npcHandler:setTopic(playerId, 2)
 	elseif MsgContains(message, "assistance") then
 		if npcHandler:getTopic(playerId) == 2 then

--- a/data/npclua/klom_stonecutter.lua
+++ b/data/npclua/klom_stonecutter.lua
@@ -67,7 +67,7 @@ local function greetCallback(npc, creature)
 		{
 			"Greetings. A warning straight ahead: I don't like loiterin'. If you're not here to {help} us, you're here to waste my time. Which I consider loiterin'. Now, try and prove your {worth} to our alliance. ... ",
 			"I have sealed some of the areas far too dangerous for anyone to enter. If you can prove you're capable, you'll get an opportunity to help destroy the weird machines, pumping lava into the caves leading to the most dangerous enemies."
-		})
+		}, 2000)
 		npcHandler:setTopic(playerId, 1)
 	end
 	return true

--- a/data/npclua/klom_stonecutter.lua
+++ b/data/npclua/klom_stonecutter.lua
@@ -53,7 +53,10 @@ end
 npcConfig.voices = {
 	interval = 15000,
 	chance = 50,
-	{text = 'abc'}
+	{text = 'Ah.'},
+	{text = 'We need more volunteers!'},
+	{text = 'And they call this "deep"...'},
+	{text = 'Preparation is paramount.'},
 }
 
 local count = {}

--- a/data/npclua/klom_stonecutter.lua
+++ b/data/npclua/klom_stonecutter.lua
@@ -53,16 +53,21 @@ end
 npcConfig.voices = {
 	interval = 15000,
 	chance = 50,
-	{text = 'abc'} }
-local quantidade = {}
+	{text = 'abc'}
+}
+
+local count = {}
 
 local function greetCallback(npc, creature)
 	local player = Player(creature)
 	local playerId = player:getId()
 
 	if player then
-		npcHandler:setMessage(MESSAGE_GREET, {"Greetings. A warning straight ahead: I don't like loiterin'. If you're not here to {help} us, you're here to waste my time. Which I consider loiterin'. Now, try and prove your {worth} to our alliance. ... ",
-											  "I have sealed some of the areas far too dangerous for anyone to enter. If you can prove you're capable, you'll get an opportunity to help destroy the weird machines, pumping lava into the caves leading to the most dangerous enemies."})
+		npcHandler:setMessage(MESSAGE_GREET,
+		{
+			"Greetings. A warning straight ahead: I don't like loiterin'. If you're not here to {help} us, you're here to waste my time. Which I consider loiterin'. Now, try and prove your {worth} to our alliance. ... ",
+			"I have sealed some of the areas far too dangerous for anyone to enter. If you can prove you're capable, you'll get an opportunity to help destroy the weird machines, pumping lava into the caves leading to the most dangerous enemies."
+		})
 		npcHandler:setTopic(playerId, 1)
 	end
 	return true
@@ -186,52 +191,52 @@ local function creatureSayCallback(npc, creature, type, message)
 		npcHandler:say({"If you bring me any suspicious devices on creatures you slay down here, I'll make it worth your while by telling the others of your generosity. How many do you want to offer? "}, npc, creature)
 		npcHandler:setTopic(playerId, 55)
 	elseif npcHandler:getTopic(playerId) == 55 then
-		quantidade[playerId] = tonumber(message)
-		if quantidade[playerId] then
-			if quantidade[playerId] > 1 then
+		count[playerId] = tonumber(message)
+		if count[playerId] then
+			if count[playerId] > 1 then
 				plural = plural .. "s"
 			end
-			npcHandler:say({"You want to offer " .. quantidade[playerId] .. " suspicious device" ..plural.. ". Which leader shall have it, (Gnomus) of the {gnomes}, (Klom Stonecutter) of the {dwarves} or the {scouts} (Lardoc Bashsmite)?"}, npc, creature)
+			npcHandler:say({"You want to offer " .. count[playerId] .. " suspicious device" ..plural.. ". Which leader shall have it, (Gnomus) of the {gnomes}, (Klom Stonecutter) of the {dwarves} or the {scouts} (Lardoc Bashsmite)?"}, npc, creature)
 			npcHandler:setTopic(playerId, 56)
 		else
 			npcHandler:say({"Don't waste my time."}, npc, creature)
 			npcHandler:setTopic(playerId, 1)
 		end
 	elseif MsgContains(message, "gnomes") and npcHandler:getTopic(playerId) == 56 then
-		if player:getItemCount(30888) >= quantidade[playerId] then
+		if player:getItemCount(30888) >= count[playerId] then
 			npcHandler:say({"Done."}, npc, creature)
-			if quantidade[playerId] > 1 then
+			if count[playerId] > 1 then
 				plural = plural .. "s"
 			end
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. quantidade[playerId] .." point"..plural.." on the gnomes mission.")
-			player:removeItem(30888, quantidade[playerId])
-			player:setStorageValue(Storage.DangerousDepths.Gnomes.Status, player:getStorageValue(Storage.DangerousDepths.Gnomes.Status) + quantidade[playerId])
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. count[playerId] .." point"..plural.." on the gnomes mission.")
+			player:removeItem(30888, count[playerId])
+			player:setStorageValue(Storage.DangerousDepths.Gnomes.Status, player:getStorageValue(Storage.DangerousDepths.Gnomes.Status) + count[playerId])
 		else
 			npcHandler:say({"You don't have enough suspicious devices."}, npc, creature)
 			npcHandler:setTopic(playerId, 1)
 		end
 	elseif MsgContains(message, "dwarves") and npcHandler:getTopic(playerId) == 56 then
-		if player:getItemCount(30888) >= quantidade[playerId] then
+		if player:getItemCount(30888) >= count[playerId] then
 			npcHandler:say({"Done."}, npc, creature)
-			if quantidade[playerId] > 1 then
+			if count[playerId] > 1 then
 				plural = plural .. "s"
 			end
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. quantidade[playerId] .." point"..plural.." on the dwarves mission.")
-			player:removeItem(30888, quantidade[playerId])
-			player:setStorageValue(Storage.DangerousDepths.Dwarves.Status, player:getStorageValue(Storage.DangerousDepths.Dwarves.Status) + quantidade[playerId])
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. count[playerId] .." point"..plural.." on the dwarves mission.")
+			player:removeItem(30888, count[playerId])
+			player:setStorageValue(Storage.DangerousDepths.Dwarves.Status, player:getStorageValue(Storage.DangerousDepths.Dwarves.Status) + count[playerId])
 		else
 			npcHandler:say({"You don't have enough suspicious devices."}, npc, creature)
 			npcHandler:setTopic(playerId, 1)
 		end
 	elseif MsgContains(message, "scouts") and npcHandler:getTopic(playerId) == 56 then
-		if player:getItemCount(30888) >= quantidade[playerId] then
+		if player:getItemCount(30888) >= count[playerId] then
 			npcHandler:say({"Done."}, npc, creature)
-			if quantidade[playerId] > 1 then
+			if count[playerId] > 1 then
 				plural = plural .. "s"
 			end
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. quantidade[playerId] .." point"..plural.." on the scouts mission.")
-			player:removeItem(30888, quantidade[playerId])
-			player:setStorageValue(Storage.DangerousDepths.Scouts.Status, player:getStorageValue(Storage.DangerousDepths.Scouts.Status) + quantidade[playerId])
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You earned ".. count[playerId] .." point"..plural.." on the scouts mission.")
+			player:removeItem(30888, count[playerId])
+			player:setStorageValue(Storage.DangerousDepths.Scouts.Status, player:getStorageValue(Storage.DangerousDepths.Scouts.Status) + count[playerId])
 		else
 			npcHandler:say({"You don't have enough suspicious devices."}, npc, creature)
 			npcHandler:setTopic(playerId, 1)


### PR DESCRIPTION
Resolves #486

Added delay to the function "NpcHandler:setMessage" and fixed talkDelay from the others functions. 
The modifications only apply to speeches that contain more than one message.

For example: 
```lua
npcHandler:say({"message1", "message2"})
```
```lua
npcHandler:setMessage(MESSAGE_GREET, {"message1", "message2"})
```

Example of manual delayed message:
For example: 
```lua
npcHandler:say({"message1", "message2", npc, player, 5000})
```
```lua
npcHandler:setMessage(MESSAGE_GREET, {"message1", "message2"}, 5000)
```

5000 = 5 seconds of interval from each message
If the delay is not added to one of the functions, the default delay of 1 second interval between each message will be added