### PR TITLE
[Fix] Fix 'wound' bestiary charm register

### DIFF
--- a/data/scripts/bestiary/charms.lua
+++ b/data/scripts/bestiary/charms.lua
@@ -1,6 +1,6 @@
 local charms = {
 	-- Wound charm
-	[0] = {
+	[1] = {
 		name = "Wound",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as physical damage once.",
@@ -14,7 +14,7 @@ local charms = {
 		points = 600
 	},
 	-- Enflame charm
-	[1] = {
+	[2] = {
 		name = "Enflame",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as fire damage once.",
@@ -28,7 +28,7 @@ local charms = {
 		points = 1000
 	},
 	-- Poison charm
-	[2] = {
+	[3] = {
 		name = "Poison",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as earth damage once.",
@@ -42,7 +42,7 @@ local charms = {
 		points = 600
 	},
 	-- Freeze charm
-	[3] = {
+	[4] = {
 		name = "Freeze",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as ice damage once.",
@@ -56,7 +56,7 @@ local charms = {
 		points = 800
 	},
 	--Zap charm
-	[4] = {
+	[5] = {
 		name = "Zap",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as energy damage once.",
@@ -70,7 +70,7 @@ local charms = {
 		points = 800
 	},
 	--Curse charm
-	[5] = {
+	[6] = {
 		name = "Curse",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as death damage once.",
@@ -84,7 +84,7 @@ local charms = {
 		points = 900
 	},
 	-- Cripple charm
-	[6] = {
+	[7] = {
 		name = "Cripple",
 		description = "Cripples the creature with a certain chance and paralyzes it for 10 seconds.",
 		type = CHARM_OFFENSIVE,
@@ -93,7 +93,7 @@ local charms = {
 		points = 500
 	},
 	-- Parry charm
-	[7] = {
+	[8] = {
 		name = "Parry",
 		description = "Any damage taken is reflected to the aggressor with a certain chance.",
 		type = CHARM_DEFENSIVE,
@@ -105,7 +105,7 @@ local charms = {
 		points = 1000
 	},
 	-- Dodge charm
-	[8] = {
+	[9] = {
 		name = "Dodge",
 		description = "Dodges an attack with a certain chance without taking any damage at all.",
 		type = CHARM_DEFENSIVE,
@@ -115,7 +115,7 @@ local charms = {
 		points = 600
 	},
 	-- Adrenaline burst charm
-	[9] = {
+	[10] = {
 		name = "Adrenaline Burst",
 		description = "Bursts of adrenaline enhance your reflexes with a certain chance \z
                        after you get hit and let you move faster for 10 seconds.",
@@ -125,7 +125,7 @@ local charms = {
 		points = 500
 	},
 	-- Numb charm
-	[10] = {
+	[11] = {
 		name = "Numb",
 		description = "Numbs the creature with a certain chance after its attack and paralyzes the creature for 10 seconds.",
 		type = CHARM_DEFENSIVE,
@@ -134,7 +134,7 @@ local charms = {
 		points = 500
 	},
 	-- Cleanse charm
-	[11] = {
+	[12] = {
 		name = "Cleanse",
 		description = "Cleanses you from within with a certain chance after you get hit and \z
                        removes one random active negative status effect and temporarily makes you immune against it.",
@@ -144,7 +144,7 @@ local charms = {
 		points = 700
 	},
 	-- Bless charm
-	[12] = {
+	[13] = {
 		name = "Bless",
 		description = "Blesses you and reduces skill and xp loss by 10% when killed by the chosen creature.",
 		type = CHARM_PASSIVE,
@@ -153,7 +153,7 @@ local charms = {
 		points = 800
 	},
 	-- Scavenge charm
-	[13] = {
+	[14] = {
 		name = "Scavenge",
 		description = "Enhances your chances to successfully skin/dust a skinnable/dustable creature.",
 		type = CHARM_PASSIVE,
@@ -161,7 +161,7 @@ local charms = {
 		points = 800
 	},
 	-- Gut charm
-	[14] = {
+	[15] = {
 		name = "Gut",
 		description = "Gutting the creature yields 20% more creature products.",
 		type = CHARM_PASSIVE,
@@ -169,7 +169,7 @@ local charms = {
 		points = 800,
 	},
 	-- Low blow charm
-	[15] = {
+	[16] = {
 		name = "Low Blow",
 		description = "Adds 8% critical hit chance to attacks with critical hit weapons.",
 		type = CHARM_PASSIVE,
@@ -178,7 +178,7 @@ local charms = {
 		points = 2000
 	},
 	-- Divine wrath charm
-	[16] = {
+	[17] = {
 		name = "Divine Wrath",
 		description = "Triggers on a creature with a certain chance and deals 5% \z
                        of its initial hit points as holy damage once.",
@@ -192,7 +192,7 @@ local charms = {
 		points = 1500
 	},
 	-- Vampiric embrace charm
-	[17] = {
+	[18] = {
 		name = "Vampiric Embrace",
 		description = "Adds 4% Life Leech to attacks if wearing equipment that provides life leech.",
 		type = CHARM_PASSIVE,
@@ -201,7 +201,7 @@ local charms = {
 		points = 1500
 	},
 	-- Void's call charm
-	[18] = {
+	[19] = {
 		name = "Void's Call",
 		description = "Adds 2% Mana Leech to attacks if wearing equipment that provides mana leech.",
 		type = CHARM_PASSIVE,
@@ -212,7 +212,7 @@ local charms = {
 }
 
 for charmId, chamsTable in ipairs(charms) do
-	local charm = Game.createBestiaryCharm(charmId)
+	local charm = Game.createBestiaryCharm(charmId - 1)
 	local charmConfig = {}
 
 	if chamsTable.name then


### PR DESCRIPTION
# Description
WOUND bestiary charm was not showing on the cyclopedia charm store due to one miss config on the LUA file.

Resolves #497

# Sync
Don't forget to implement the Canary PR https://github.com/opentibiabr/canary/pull/271