### PR TITLE
Fix party skills

### DIFF
--- a/data/scripts/spells/party/heal_party.lua
+++ b/data/scripts/spells/party/heal_party.lua
@@ -14,7 +14,7 @@ local baseMana = 120
 
 local spell = Spell("instant")
 
-function spell.onCastSpell(creature, variant)
+function spell.onCastSpell(creature, var)
 	local position = creature:getPosition()
 
 	local party = creature:getParty()

--- a/data/scripts/spells/party/protect_party.lua
+++ b/data/scripts/spells/party/protect_party.lua
@@ -7,14 +7,14 @@ local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_SUBID, 2)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, 1)
 condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
-condition:setParameter(CONDITION_PARAM_SKILL_SHIELD, 2)
+condition:setParameter(CONDITION_PARAM_SKILL_SHIELD, 3)
 
 local baseMana = 90
 
 local spell = Spell("instant")
 
-function spell.onCastSpell(creature, variant)
-	local position = creature:getPosition()
+function spell.onCastSpell(creature, var)
+local position = creature:getPosition()
 
 	local party = creature:getParty()
 	if not party then

--- a/data/scripts/spells/party/train_party.lua
+++ b/data/scripts/spells/party/train_party.lua
@@ -14,7 +14,7 @@ local baseMana = 60
 
 local spell = Spell("instant")
 
-function spell.onCastSpell(creature, variant)
+function spell.onCastSpell(creature, var)
 	local position = creature:getPosition()
 
 	local party = creature:getParty()


### PR DESCRIPTION
# Description

This PR contains fix naming for `variable` parameter in onCastSpell for train_party, heal_party and protect_party scripts. Additionally, shielding buff has been changed from 2 to 3 to match real tibia skill

