### PR TITLE
[Fix] Add healing source on 'mass healing' and potions

### DIFF
--- a/data/scripts/actions/other/potions.lua
+++ b/data/scripts/actions/other/potions.lua
@@ -248,11 +248,11 @@ function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHot
 
 	if potion.health or potion.mana or potion.combat then
 		if potion.health then
-			doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
+			doTargetCombatHealth(player, target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
 		end
 
 		if potion.mana then
-			doTargetCombatMana(0, target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
+			doTargetCombatMana(player, target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
 		end
 
 		if potion.combat then

--- a/data/scripts/spells/healing/mass_healing.lua
+++ b/data/scripts/spells/healing/mass_healing.lua
@@ -11,7 +11,7 @@ function onTargetCreature(creature, target)
 		end
 	end
 
-	doTargetCombatHealth(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
+	doTargetCombatHealth(player, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end
 


### PR DESCRIPTION
# Description
Using the spell 'exura gran mas res' or using a health potion on another player is not registering the source of the action. This PR add it so the server, the client and other systems can track the action how it should be. 

# Canary sync
This change only works with Party hunt analyzer PR https://github.com/opentibiabr/canary/pull/262

# Actual
![image](https://user-images.githubusercontent.com/66353315/160252744-ac3cdaef-29f2-488a-908e-6b9bfbd6d588.png)

# Expected
![image](https://user-images.githubusercontent.com/66353315/160252755-b9c55dd0-385c-40fc-b9c3-82cd3d5f87b4.png)
