### PR TITLE
Fix levitate and parcel behaviour

### DIFF
--- a/data/scripts/spells/support/levitate.lua
+++ b/data/scripts/spells/support/levitate.lua
@@ -1,16 +1,24 @@
 local function levitate(creature, parameter)
 	local fromPosition = creature:getPosition()
+	parameter = parameter:trim():lower()
 
 	if parameter == "up" and fromPosition.z ~= 8 or parameter == "down" and fromPosition.z ~= 7 then
 		local toPosition = creature:getPosition()
 		toPosition:getNextPosition(creature:getDirection())
 
 		local tile = Tile(parameter == "up" and Position(fromPosition.x, fromPosition.y, fromPosition.z - 1) or toPosition)
-		if not tile or not tile:getGround() and not tile:hasFlag(parameter == "up" and TILESTATE_IMMOVABLEBLOCKSOLID or TILESTATE_BLOCKSOLID) then
+		if not tile or not tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
 			tile = Tile(toPosition.x, toPosition.y, toPosition.z + (parameter == "up" and -1 or 1))
 
-			if tile and tile:getGround() and not tile:hasFlag(bit.bor(TILESTATE_IMMOVABLEBLOCKSOLID, TILESTATE_FLOORCHANGE)) then
-				return creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
+			if tile and tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
+				local fromPos = creature:getPosition()
+				local moved = creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
+
+				if moved == RETURNVALUE_NOERROR then
+					fromPos:sendMagicEffect(CONST_ME_TELEPORT)
+				end
+
+				return moved			
 			end
 		end
 	end
@@ -23,11 +31,10 @@ function spell.onCastSpell(creature, variant)
 	local returnValue = levitate(creature, variant:getString():lower())
 	if returnValue ~= RETURNVALUE_NOERROR then
 		creature:sendCancelMessage(returnValue)
-		creature:getPosition():sendMagicEffect(CONST_ME_POFF)
-		return false
-	end
 
-	creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+	return false
+end
 	return true
 end
 


### PR DESCRIPTION
**Changes Proposed**
make levitate and parcel behaviour more accurate
remove floorchange check from levitate, replace checked tilestate to immovableblocksolid
needs testing

**expected behaviour:**
POSSIBLE: levitating/parcel walking to tiles blocked by furniture
POSSIBLE: levitating/parcel walking to tiles like 459
NOT POSSIBLE: levitating/parcel walking to walls, immovable obstacles or unwalkable grounds
NOT POSSIBLE levitating/parcel walking to tiles with PVP magic walls



