### PR TITLE
fix: fixes #528, keys would be given without proper key actions

### DIFF
--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -86,7 +86,8 @@ ChestUnique = {
 		container = 2853,
 		reward = {{2970, 1}, {3598, 20}, {3598, 7}},
 		weight = 44,
-		storage = Storage.Quest.Key.ID3801
+		storage = Storage.Quest.Key.ID3801,
+		keyAction = Storage.Quest.Key.ID3801
 	},
 	-- Emperor's cookies quest key 2299
 	[5005] = {
@@ -118,7 +119,8 @@ ChestUnique = {
 		container = 2853,
 		reward = {{2970, 1}, {3031, 23}, {3147, 1}, {3298, 4}, {3384, 1}},
 		weight = 80,
-		storage = Storage.Quest.Key.ID4502
+		storage = Storage.Quest.Key.ID4502,
+		keyAction = Storage.Quest.Key.ID4502
 	},
 	[5009] = {
 		isKey = true,


### PR DESCRIPTION
# Description

This pull request fixed issue #528 where some keys are given without proper key actions.
This change only applies for objects that have `isKey`=true + `container` + `storage`, in other words, this bug only happens when keys are inside containers (bags, backpacks, such thing...).

## Behaviour
### Keys given without proper key action.

Try to start the `Emperor's cookies quest`, finding the keys inside the quest chests will gives you keys with incorrect key actions setted.

### **Expected**
Keys with correct key actions (3800, 3801 and 3802).

## Fixes

\#528

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - Move yourself to position {x = 32605, y = 31908, z = 3}
  - Try to get the key from the chest
  - Look the key, will show you the correct key action (3800)

**Test Configuration**:

  - Server Version: 12.58
  - Client: 12.58
  - Operating System: Linux

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
