### PR TITLE
Fix Vocation Familiars able to attack players even with secure mode on

### DIFF
--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -114,8 +114,12 @@ function Creature:onTargetCombat(target)
 
 	local master = self:getMaster()
 	if master and target:isPlayer() then
-		if master:hasSecureMode() or not master:isPzLocked() then
+		if master:hasSecureMode() then
 			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER
+		elseif not master:isPzLocked() and not target:isPzLocked() then
+			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER
+		else
+			return
 		end
 	end
 

--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -112,6 +112,13 @@ function Creature:onTargetCombat(target)
 		end
 	end
 
+	local master = self:getMaster()
+	if master and target:isPlayer() then
+		if master:hasSecureMode() or not master:isPzLocked() then
+			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER
+		end
+	end
+
 	self:addEventStamina(target)
 	return true
 end


### PR DESCRIPTION
# Description

This PR is to fix an issue that could be exploited by players.

## Behaviour
### **Actual**

You can target a monster next to a player and hit him with your familiar without getting PZ nor white skull, and even if you have secure mode turned on.

### **Expected**

Your familiar will only be able to attack players if you have secure mode off (hands closed) and PZ locked and with , or if opponent is PZ Locked.

## Fixes


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Summon a Paladin familiar, and start attacking a monster at the side of a player. 
If you have secure mode on, your familiar will not hit any player at all.
If you have secure mode off, but is not PzLocked, your familiar will hit only players who are PzLocked.
If you have secure mode off and is PzLocked, your familiar will hit any player.


## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
