### PR TITLE
Fix weapons shoot effects and eldritch wands/rods not attacking

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -32956,10 +32956,6 @@
 		<attribute key="weight" value="3500"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
-			<attribute key="elemental protection earth" value="3"/>
-			<attribute key="elemental protection fire" value="3"/>
-			<attribute key="elemental protection ice" value="3"/>
-			<attribute key="elemental protection energy" value="3"/>
 			<attribute key="elemental protection holy" value="3"/>
 			<attribute key="skillboost shielding" value="3"/>
 		</attribute>
@@ -32975,10 +32971,6 @@
 		<attribute key="weight" value="3000"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
-			<attribute key="elemental protection earth" value="3"/>
-			<attribute key="elemental protection fire" value="3"/>
-			<attribute key="elemental protection ice" value="3"/>
-			<attribute key="elemental protection energy" value="3"/>
 			<attribute key="elemental protection holy" value="3"/>
 			<attribute key="skillboost shielding" value="3"/>
 		</attribute>
@@ -45679,7 +45671,6 @@
 		<attribute key="weight" value="3500"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
-			<attribute key="elemental protection earth" value="3"/>
 			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
 			<attribute key="elemental protection energy" value="3"/>
@@ -45768,7 +45759,6 @@
 		<attribute key="weight" value="2700"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
-			<attribute key="elemental protection earth" value="3"/>
 			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
 			<attribute key="elemental protection energy" value="3"/>
@@ -45829,7 +45819,6 @@
 			<attribute key="elemental protection earth" value="3"/>
 			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
-			<attribute key="elemental protection energy" value="3"/>
 			<attribute key="elemental protection holy" value="3"/>
 			<attribute key="skillboost shielding" value="3"/>
 		</attribute>
@@ -50317,7 +50306,6 @@
 		<attribute key="weight" value="7200"/>
 		<attribute key="upgradeclassification" value="3"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -52235,7 +52223,6 @@
 		<attribute key="weight" value="6300"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -52255,7 +52242,6 @@
 		<attribute key="weight" value="8100"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -52277,7 +52263,6 @@
 		<attribute key="weight" value="4000"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -52297,7 +52282,6 @@
 		<attribute key="weight" value="7200"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -52451,7 +52435,6 @@
 			<attribute key="life leech" value="3"/>
 			<attribute key="elemental protection death" value="3"/>
 			<attribute key="elemental protection earth" value="3"/>
-			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
 			<attribute key="elemental protection energy" value="3"/>
 			<attribute key="elemental protection holy" value="3"/>
@@ -52485,7 +52468,6 @@
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="life leech" value="3"/>
-			<attribute key="elemental protection death" value="3"/>
 			<attribute key="elemental protection earth" value="3"/>
 			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
@@ -53224,7 +53206,6 @@
 		<attribute key="weight" value="7900"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -54376,7 +54357,6 @@
 		<attribute key="weight" value="8500"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -54395,7 +54375,6 @@
 		<attribute key="weight" value="8600"/>
 		<attribute key="upgradeclassification" value="4"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -54616,7 +54595,6 @@
 		<attribute key="weight" value="2800"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
-			<attribute key="elemental protection earth" value="3"/>
 			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
 			<attribute key="elemental protection energy" value="3"/>
@@ -54634,7 +54612,6 @@
 		<attribute key="imbuementslot" value="1">
 			<attribute key="elemental protection death" value="3"/>
 			<attribute key="elemental protection earth" value="3"/>
-			<attribute key="elemental protection fire" value="3"/>
 			<attribute key="elemental protection ice" value="3"/>
 			<attribute key="elemental protection energy" value="3"/>
 			<attribute key="elemental protection holy" value="3"/>

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -17453,7 +17453,7 @@
 	<item id="8083" article="a" name="northwind rod">
 		<attribute key="description" value="It was made by one of the shamans in Svargrond and symbolises an icy mammoth"/>
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="ice"/>
+		<attribute key="shootType" value="smallice"/>
 		<attribute key="range" value="3"/>
 		<attribute key="weight" value="2900"/>
 		<attribute key="upgradeclassification" value="1"/>
@@ -40020,7 +40020,7 @@
 	<item id="25700" article="a" name="dream blossom staff">
 		<attribute key="description" value="It's a gnarly branch with a gleaming blue blossom"/>
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="death"/>
+		<attribute key="shootType" value="energy"/>
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3200"/>
@@ -40192,6 +40192,7 @@
 	<item id="25760" article="a" name="wand of darkness">
 		<attribute key="description" value="Temporary magic powers enchant this staff."/>
 		<attribute key="weaponType" value="wand"/>
+		<attribute key="shootType" value="death"/>
 		<attribute key="stopduration" value="0"/>
 		<attribute key="showduration" value="1"/>
 		<attribute key="magicpoints" value="2"/>
@@ -42387,7 +42388,7 @@
 	</item>
 	<item id="27458" article="a" name="rod of destruction">
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="ice"/>
+		<attribute key="shootType" value="smallice"/>
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3500"/>
@@ -44443,7 +44444,7 @@
 	</item>
 	<item id="28716" article="a" name="falcon rod">
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="smallearth"/>
+		<attribute key="shootType" value="earth"/>
 		<attribute key="absorbpercentenergy" value="8"/>
 		<attribute key="magicpoints" value="3"/>
 		<attribute key="range" value="5"/>
@@ -47383,6 +47384,7 @@
 	</item>
 	<item id="30399" name="cobra wand">
 		<attribute key="weaponType" value="wand"/>
+		<attribute key="shootType" value="energy"/>
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="criticalhitdamage" value="35"/>
 		<attribute key="criticalhitchance" value="10"/>
@@ -47397,6 +47399,7 @@
 	</item>
 	<item id="30400" name="cobra rod">
 		<attribute key="weaponType" value="wand"/>
+		<attribute key="shootType" value="smallearth"/>
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="lifeleechamount" value="18"/>
 		<attribute key="lifeleechchance" value="100"/>
@@ -54639,7 +54642,7 @@
 	</item>
 	<item id="36674" article="a" name="eldritch rod">
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="ice"/>
+		<attribute key="shootType" value="smallice"/>
 		<attribute key="loottype" value="wand"/>
 		<attribute key="absorbpercentpoison" value="4"/>
 		<attribute key="magicpoints" value="2"/>
@@ -54658,7 +54661,7 @@
 	<item id="36675" article="a" name="gilded eldritch rod">
 		<attribute key="description" value="Refined by the legendary artisan Gnomaurum"/>
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="ice"/>
+		<attribute key="shootType" value="smallice"/>
 		<attribute key="loottype" value="wand"/>
 		<attribute key="absorbpercentpoison" value="4"/>
 		<attribute key="magicpoints" value="2"/>

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -34704,6 +34704,7 @@
 	<item fromid="21398" toid="21399" article="a" name="dead goblin"/>
 	<item id="21400" article="a" name="spellbook of the novice">
 		<attribute key="description" value="It shows your spells and can also shield against attacks when worn"/>
+		<attribute key="weaponType" value="shield"/>
 		<attribute key="defense" value="8"/>
 		<attribute key="weight" value="1400"/>
 	</item>

--- a/data/scripts/weapons/unscripted_weapons.lua
+++ b/data/scripts/weapons/unscripted_weapons.lua
@@ -3,7 +3,10 @@ local weapons = {
 		-- gilded eldritch rod
 		itemId = 36675,
 		type = WEAPON_WAND,
+		wandType = "ice",
 		level = 250,
+		mana = 22,
+		damage = {85, 105},
 		unproperly = true,
 		vocation = {
 			{"Druid", true},
@@ -14,7 +17,10 @@ local weapons = {
 		-- eldritch rod
 		itemId = 36674,
 		type = WEAPON_WAND,
+		wandType = "ice",
 		level = 250,
+		mana = 22,
+		damage = {85, 105},
 		unproperly = true,
 		vocation = {
 			{"Druid", true},
@@ -25,7 +31,10 @@ local weapons = {
 		-- gilded eldritch wand
 		itemId = 36669,
 		type = WEAPON_WAND,
+		wandType = "fire",
 		level = 250,
+		mana = 22,
+		damage = {85, 105},
 		unproperly = true,
 		vocation = {
 			{"Sorcerer", true},
@@ -36,7 +45,10 @@ local weapons = {
 		-- eldritch wand
 		itemId = 36668,
 		type = WEAPON_WAND,
+		wandType = "fire",
 		level = 250,
+		mana = 22,
+		damage = {85, 105},
 		unproperly = true,
 		vocation = {
 			{"Sorcerer", true},


### PR DESCRIPTION
Fixes some weapon shootTypes that were wrong in items.xml, and insert eldritch wands and rods on unscripted weapons in order to work properly.
Also, fixed some imbuements info on elemental weapons and elemental sets (elemental weapons and equipments that have protection elemental, can't have a imbuement with the same element).