### PR TITLE
(Canary Compatibility) move version from config.lua to definitions.h

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -42,10 +42,6 @@ maxPacketsPerSecond = 25
 maxItem = 2000
 maxContainer = 100
 
--- Version
-clientVersion = 1285
-clientVersionStr = "12.85"
-
 -- Depot Limit
 freeDepotLimit = 2000
 premiumDepotLimit = 10000


### PR DESCRIPTION
Need canary commit: https://github.com/opentibiabr/canary/commit/4580324c18a69289db7ba346f04eec2d30188136