### PR TITLE
Fix daily reward itemId typo

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -461,15 +461,15 @@ function Player.selectDailyReward(self, msg)
 		for k, v in ipairs(items) do
 			if dailyTable.itemCharges then
 				for i = 1, v.count do
-					inbox:addItem(v.ItemId, dailyTable.itemCharges) -- adding charges for each item
+					inbox:addItem(v.itemId, dailyTable.itemCharges) -- adding charges for each item
 				end
 			else
-				inbox:addItem(v.ItemId, v.count) -- adding single item w/o charges
+				inbox:addItem(v.itemId, v.count) -- adding single item w/o charges
 			end
 			if k ~= columnsPicked then
-				description = description .. "" .. v.count .. "x " .. getItemName(v.ItemId) .. ", "
+				description = description .. "" .. v.count .. "x " .. getItemName(v.itemId) .. ", "
 			else
-				description = description .. "" .. v.count .. "x " .. getItemName(v.ItemId) .. "."
+				description = description .. "" .. v.count .. "x " .. getItemName(v.itemId) .. "."
 			end
 		end
 


### PR DESCRIPTION
# Description
Fix small typo on daily_reward lua script.

## Behaviour
### **Items weren't sent to Store inbox**

Do this and that doesn't happens

### **The collected itens by players should be available at inbox store**

## Fixes

fixes #587

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  
## How Has This Been Tested

Opening characters sample on client and collecting daily reward

**Test Configuration**:

  - Server Version: 1.3.1
  - Client: 12.86
  - Operating System: Windows

## Checklist
  - [x] My code follows the style guidelines of this project
  