### PR TITLE
Ajusted Infernalist and hellspawn with duplicated item id

### DIFF
--- a/data/monster/demons/hellspawn.lua
+++ b/data/monster/demons/hellspawn.lua
@@ -98,7 +98,7 @@ monster.loot = {
 	{id = 8895, chance = 3125},
 	{id = 8896, chance = 3125},
 	{id = 9034, chance = 140},
-	{name = "black skull", chance = 151},
+	{id = 9056, chance = 151},
 	{name = "small topaz", chance = 5882, maxCount = 3},
 	{name = "hellspawn tail", chance = 20000}
 }

--- a/data/monster/humans/infernalist.lua
+++ b/data/monster/humans/infernalist.lua
@@ -99,7 +99,7 @@ monster.loot = {
 	{name = "raspberry", chance = 8500, maxCount = 5},
 	{name = "spellbook of mind control", chance = 370},
 	{name = "royal tapestry", chance = 520},
-	{name = "black skull", chance = 820},
+	{id = 9056, chance = 820},
 	{name = "gold ingot", chance = 70},
 	{name = "crystal of power", chance = 220}
 }


### PR DESCRIPTION
# Description
Litle warning of black skull item id duplication on otservbr global data pack
 
##
## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

Check the logs to see if warn was gone 

**Test Configuration**:

  - Server Version:   - 1.3.1
  - Client: 12.86
  - Operating System: Windows 11

## Checklist
  - [x] My code follows the style guidelines of this project
