### PR TITLE
Update diamond arrow formula

### DIFF
--- a/data/scripts/weapons/scripts/diamond_arrow.lua
+++ b/data/scripts/weapons/scripts/diamond_arrow.lua
@@ -1,9 +1,9 @@
 local area = createCombatArea({
- 	{0, 1, 1, 1, 0},
- 	{1, 1, 1, 1, 1},
- 	{1, 1, 3, 1, 1},
-	{1, 1, 1, 1, 1},
-	{0, 1, 1, 1, 0},
+     {0, 1, 1, 1, 0},
+     {1, 1, 1, 1, 1},
+     {1, 1, 3, 1, 1},
+     {1, 1, 1, 1, 1},
+     {0, 1, 1, 1, 0},
  })
 
 local combat = Combat()
@@ -14,7 +14,7 @@ combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 function onGetFormulaValues(player, skill, attack, factor)
     local distanceSkill = player:getEffectiveSkillLevel(SKILL_DISTANCE)
     local min = (player:getLevel() / 5)
-    local max = (0.09 * 1 * distanceSkill * 37) + (player:getLevel() / 5)
+    local max = (0.09 * factor) * distanceSkill * 37 + (player:getLevel() / 5)
     return -min, -max
 end
 
@@ -24,7 +24,7 @@ combat:setArea(area)
 local diamondArrow = Weapon(WEAPON_AMMO)
 
 function diamondArrow.onUseWeapon(player, variant)
-	return combat:execute(player, variant)
+    return combat:execute(player, variant)
 end
 
 diamondArrow:id(25757)

--- a/data/scripts/weapons/scripts/diamond_arrow.lua
+++ b/data/scripts/weapons/scripts/diamond_arrow.lua
@@ -11,7 +11,14 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_DIAMONDARROW)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
-combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
+function onGetFormulaValues(player, skill, attack, factor)
+    local distanceSkill = player:getEffectiveSkillLevel(SKILL_DISTANCE)
+    local min = (player:getLevel() / 5)
+    local max = (0.09 * 1 * distanceSkill * 37) + (player:getLevel() / 5)
+    return -min, -max
+end
+
+combat:setCallback(CALLBACK_PARAM_SKILLVALUE, "onGetFormulaValues")
 combat:setArea(area)
 
 local diamondArrow = Weapon(WEAPON_AMMO)


### PR DESCRIPTION
updating the formulas to be the same as the global. Previously a level 1500 with distance 125 could hit 20


# Description

the old attack formula had totally inconsistent hits
in this formula using the wiki formula we have an honest value and close to the original



## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] I have performed a self-review of my own code
