### PR TITLE
Fix wrong decayID that could cause debug on client

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -39534,7 +39534,7 @@
 	<item fromid="27538" toid="27541" name="RESERVED SPRITE"/>
 	<item id="27542" article="a" name="dead deepworm">
 		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="10"/>
+		<attribute key="decayTo" value="0"/>
 	</item>
 	<item id="27543" article="a" name="dead deepworm">
 		<attribute key="fluidsource" value="blood"/>


### PR DESCRIPTION
Fixes a debug issue for the client


# Description

Previously the decay caused a debug issue in the warzone 6 area. The standard map has a dead deepworm spawn at server save on the western side, which would debug. As soon as anyone initially entered warzone 6 and killed the monsters at the entrance, no other player could enter after without also debugging. 

## Behaviour
### **Actual**

Corpse decays to an item ID that causes a debug when walking on the screen

### **Expected**

Corpse should decay to nothing at final stage

## Fixes

Change to decay ID

## Type of change

datapack

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Tested by changing the items.xml and then killing the monsters at the entrance. After waiting the required time for the full decay, I reentered the area to ensure no debugs. The one that spawns on the map also decays correctly and that area is now safe to go to once again. 

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 1.3.1
  - Client: 12.86
  - Operating System: Ubuntu 20.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
