### PR TITLE
Fixed Donkey Tame

### DIFF
--- a/data/scripts/actions/mounts/mounts.lua
+++ b/data/scripts/actions/mounts/mounts.lua
@@ -96,6 +96,21 @@ function mounts.onUse(cid, item, fromPosition, itemEx, toPosition)
 			toPosition:sendMagicEffect(CONST_ME_MAGIC_GREEN)
 			Item(item.uid):remove(1)
 			return true
+		elseif item.itemid == 12548 and targetMonster:getOutfit().lookType == 387 then
+			if rand > mount.CHANCE then
+				doFailAction(cid, mount, toPosition, item, itemEx, mount.BREAK)
+				return true
+			end
+			if mount.ACHIEV then
+				player:addAchievement(mount.ACHIEV)
+			end
+			player:addAchievement("Natural Born Cowboy")
+			player:addMount(mount.ID)
+			player:say(mount.SUCCESS_MSG, TALKTYPE_MONSTER_SAY)
+			targetMonster:remove()
+			toPosition:sendMagicEffect(CONST_ME_MAGIC_GREEN)
+			Item(item.uid):remove(1)
+			return true
 		end
 	--NPC Mount
 	elseif targetNpc ~= nil and mount.TYPE == TYPE_NPC then


### PR DESCRIPTION
Fixed Donkey Tame


# Description

The item to tame the Donkey needs to be used on the Incredibly Old Witch or lured monsters while they are transformed into a Donkey, so the item will never match the name of the monster as "Donkey".
The change is simple only to compare if the item type and monster looktype are the ones required to tame the Donkey.

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## Checklist

  - [X] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
