### PR TITLE
Fix unexpected behavior on moving item on quest cults of tibia

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -22,7 +22,7 @@
 	<event class="Player" method="onChangeZone" enabled="1" />
 	<event class="Player" method="onGainExperience" enabled="1" />
 	<event class="Player" method="onGainSkillTries" enabled="1" />
-	<event class="Player" method="onItemMoved" enabled="0" />
+	<event class="Player" method="onItemMoved" enabled="1" />
 	<event class="Player" method="onLook" enabled="1" />
 	<event class="Player" method="onLookInBattleList" enabled="1" />
 	<event class="Player" method="onLookInShop" enabled="0" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -451,7 +451,7 @@ end
 
 function Player:onItemMoved(item, count, fromPosition, toPosition, fromCylinder, toCylinder)
 	-- Cults of Tibia begin
-	local frompos = Position(33023, 31904, 15) -- Checagem
+	local frompos = Position(33023, 31904, 14) -- Checagem
 	local topos = Position(33052, 31932, 15) -- Checagem
 	local removeItem = false
 	if self:getPosition():isInRange(frompos, topos) and item:getId() == 23729 then
@@ -472,6 +472,7 @@ function Player:onItemMoved(item, count, fromPosition, toPosition, fromCylinder,
 				Game.setStorageValue('CheckTile', os.time()+30)
 			elseif tileBoss:getTopCreature():getName():lower() == 'the corruptor of souls' then
 				Game.setStorageValue('CheckTile', os.time()+30)
+				removeItem = true
 			end
 		end
 		if removeItem then

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -286,7 +286,6 @@ local function antiPush(self, item, count, fromPosition, toPosition, fromCylinde
 end
 
 function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, toCylinder)
-
 	-- No move items with actionID = 100
 	if item:getActionId() == NOT_MOVEABLE_ACTION then
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
@@ -316,32 +315,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 			return false
 		end
 	end
-
-	-- Cults of Tibia begin
-	local frompos = Position(33023, 31904, 14) -- Checagem
-	local topos = Position(33052, 31932, 15) -- Checagem
-	if self:getPosition():isInRange(frompos, topos) and item:getId() == 23729 then
-		local tileBoss = Tile(toPosition)
-		if tileBoss and tileBoss:getTopCreature() and tileBoss:getTopCreature():isMonster() then
-			if tileBoss:getTopCreature():getName():lower() == 'the remorseless corruptor' then
-				tileBoss:getTopCreature():addHealth(-17000)
-				item:remove(1)
-				if tileBoss:getTopCreature():getHealth() <= 300 then
-					tileBoss:getTopCreature():remove()
-					local monster = Game.createMonster('the corruptor of souls', toPosition)
-					monster:registerEvent('CheckTile')
-					if Game.getStorageValue('healthSoul') > 0 then
-						monster:addHealth(-(monster:getHealth() - Game.getStorageValue('healthSoul')))
-					end
-					Game.setStorageValue('CheckTile', os.time()+30)
-				end
-			elseif tileBoss:getTopCreature():getName():lower() == 'the corruptor of souls' then
-				Game.setStorageValue('CheckTile', os.time()+30)
-				item:remove(1)
-			end
-		end
-	end
-	-- Cults of Tibia end
 
 	-- SSA exhaust
 	local exhaust = { }
@@ -477,6 +450,36 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 end
 
 function Player:onItemMoved(item, count, fromPosition, toPosition, fromCylinder, toCylinder)
+	-- Cults of Tibia begin
+	local frompos = Position(33023, 31904, 15) -- Checagem
+	local topos = Position(33052, 31932, 15) -- Checagem
+	local removeItem = false
+	if self:getPosition():isInRange(frompos, topos) and item:getId() == 23729 then
+		local tileBoss = Tile(toPosition)
+		if tileBoss and tileBoss:getTopCreature() and tileBoss:getTopCreature():isMonster() then
+			if tileBoss:getTopCreature():getName():lower() == 'the remorseless corruptor' then
+				tileBoss:getTopCreature():addHealth(-17000)
+				tileBoss:getTopCreature():remove()
+				local monster = Game.createMonster('The Corruptor of Souls', toPosition)
+				if not monster then
+					return false
+				end
+				removeItem = true
+				monster:registerEvent('CheckTile')
+				if Game.getStorageValue('healthSoul') > 0 then
+					monster:addHealth(-(monster:getHealth() - Game.getStorageValue('healthSoul')))
+				end
+				Game.setStorageValue('CheckTile', os.time()+30)
+			elseif tileBoss:getTopCreature():getName():lower() == 'the corruptor of souls' then
+				Game.setStorageValue('CheckTile', os.time()+30)
+			end
+		end
+		if removeItem then
+			item:remove(1)
+		end
+	end
+	-- Cults of Tibia end
+	return true
 end
 
 function Player:onMoveCreature(creature, fromPosition, toPosition)

--- a/data/scripts/lib/register_actions.lua
+++ b/data/scripts/lib/register_actions.lua
@@ -228,6 +228,32 @@ local cutItems = {
 	[25800] = 0
 }
 
+-- Ferumbras ascendant ring reward
+local function addFerumbrasAscendantReward(player, target, toPosition)
+	local stonePos = Position(32648, 32134, 10)
+	if (toPosition == stonePos) then
+		local tile = Tile(stonePos)
+		local stone = tile:getItemById(1772)
+		if stone then
+			stone:remove(1)
+			toPosition:sendMagicEffect(CONST_ME_POFF)
+			addEvent(function()
+				Game.createItem(1772, 1, stonePos)
+			end, 20000)
+			return true
+		end
+	end
+
+	if target.itemid == 10551 and target.actionid == 53803 then
+		if player:getStorageValue(Storage.FerumbrasAscendant.Ring) >= 1 then
+			return false
+		end
+
+		player:addItem(22170, 1)
+		player:setStorageValue(Storage.FerumbrasAscendant.Ring, 1)
+	end
+end
+
 function onDestroyItem(player, item, fromPosition, target, toPosition, isHotkey)
 	if not target or target == nil or type(target) ~= "userdata" or not target:isItem() then
 		return false
@@ -330,6 +356,7 @@ function onUseRope(player, item, fromPosition, target, toPosition, isHotkey)
 end
 
 function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
+	addFerumbrasAscendantReward(player, target, toPosition)
 	--Dawnport quest (Morris amulet task)
 	local sandPosition = Position(32099, 31933, 7)
 	if (toPosition == sandPosition) then


### PR DESCRIPTION
There is a problem in the onMoveItem function for this quest, it caused a crash, when moving the item on top of the monster, it was not removed, and when trying to move the item, it crashed