### PR TITLE
Fix script logic of cults of tibia quest (The Sinister Hermit)

### DIFF
--- a/data/scripts/creaturescripts/quests/cults_of_tibia/evaporate.lua
+++ b/data/scripts/creaturescripts/quests/cults_of_tibia/evaporate.lua
@@ -17,7 +17,7 @@ function spellCallback(param)
 	if tile then
 		if tile:getTopCreature() and tile:getTopCreature():isMonster() then
 			if tile:getTopCreature():getName():lower() == "leiden" then
-				tile:getTopCreature():registerEvent("SpawnBoss")
+				tile:getTopCreature():registerEvent("spawnBoss")
 				tile:getTopCreature():addHealth(-math.random(3000, 6000))
 			elseif tile:getTopCreature():getName():lower() == "ravenous hunger" then
 				tile:getTopCreature():addHealth(math.random(3000, 6000))

--- a/data/scripts/creaturescripts/quests/cults_of_tibia/evaporate.lua
+++ b/data/scripts/creaturescripts/quests/cults_of_tibia/evaporate.lua
@@ -17,7 +17,7 @@ function spellCallback(param)
 	if tile then
 		if tile:getTopCreature() and tile:getTopCreature():isMonster() then
 			if tile:getTopCreature():getName():lower() == "leiden" then
-				tile:getTopCreature():registerEvent("spawnBoss")
+				tile:getTopCreature():registerEvent("SpawnBoss")
 				tile:getTopCreature():addHealth(-math.random(3000, 6000))
 			elseif tile:getTopCreature():getName():lower() == "ravenous hunger" then
 				tile:getTopCreature():addHealth(math.random(3000, 6000))

--- a/data/scripts/movements/quests/cults_of_tibia/geyser.lua
+++ b/data/scripts/movements/quests/cults_of_tibia/geyser.lua
@@ -37,7 +37,7 @@ function geyser.onStepIn(creature, item, position, fromPosition)
 			item:remove()
 			local subtract = bossTransform:getHealth() - currentLife
 			bossTransform:addHealth(-subtract)
-			bossTransform:registerEvent("spawnBoss")
+			bossTransform:registerEvent("SpawnBoss")
 			addEvent(bossTransformBack, 4*1000, bossTransform:getId(), item:getId())
 			return true
 		end

--- a/data/scripts/movements/quests/cults_of_tibia/geyser.lua
+++ b/data/scripts/movements/quests/cults_of_tibia/geyser.lua
@@ -28,7 +28,8 @@ function geyser.onStepIn(creature, item, position, fromPosition)
 		return true
 	end
 
-	if creature:getType():getName():lower() == "the sinister hermit" and creature:getOutfit().lookBody == 63 then
+	local monsterType = creature:getType()
+	if monsterType and monsterType:getTypeName():lower() == "the sinister hermit dirty" and creature:getOutfit().lookBody == 63 then
 		local currentLife = creature:getHealth()
 		local bossTransform = Game.createMonster("the sinister hermit", creature:getPosition(), true, true)
 		if bossTransform then
@@ -38,10 +39,10 @@ function geyser.onStepIn(creature, item, position, fromPosition)
 			bossTransform:addHealth(-subtract)
 			bossTransform:registerEvent("spawnBoss")
 			addEvent(bossTransformBack, 4*1000, bossTransform:getId(), item:getId())
-			return false
+			return true
 		end
 	end
-	return true
+	return false
 end
 
 geyser:type("stepin")


### PR DESCRIPTION
Working with: https://github.com/opentibiabr/canary/pull/389/files

The real name of the monster was replaced by the name of the look, generating unexpected behavior and in a very specific scenario a crash (when two different monsters had the same "name")
Some improvements related to the creation of monsters and the verification of the monster name in getMonsterType, also preventing any unexpected behavior