### PR TITLE
Fixed questlog tracker to best follow missions with counters

### DIFF
--- a/data/lib/core/quests.lua
+++ b/data/lib/core/quests.lua
@@ -6185,7 +6185,9 @@ function Player.updateStorage(self, key, value, oldValue, currentFrameTime)
 	local playerId = self:getId()
 	if LastQuestlogUpdate[playerId] ~= currentFrameTime and Game.isQuestStorage(key, value, oldValue) then
 		LastQuestlogUpdate[playerId] = currentFrameTime
-		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your questlog has been updated.")
+        if value ~= oldValue then
+            self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your questlog has been updated.")
+        end
 	end
 	local missions = self:getMissionsData(key)
 	for i = 1, #missions do


### PR DESCRIPTION
With quests using counters like Killing In the Name of, the number of kills was not being updated dynamically on every kill, in order to update the tracker you must disable/enable the tracker for any mission. With this change you can simple add the same value to the questline and it will push the tracker to update and bring the new counters values.

### **Expected**
When killing a monster, the questlog tracker must update it automatically, it was not happening, and the tracker was keeping static until you manually disable and re-enable any mission.

## Fixes
With the change, you can use the setStorageValue on creature scripts to add the same value as your actual questline, it will trick the system to push a questlog update which will bring the new counters values to the tracker without sending the message "Your questlog has been updated."

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
