### PR TITLE
Fixing summon searching player target and icons update

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -531,7 +531,7 @@ function doConvinceCreature(cid, target)
 		return false
 	end
 
-	creature:addSummon(targetCreature)
+	creature:setSummon(targetCreature)
 	return true
 end
 

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -98,18 +98,13 @@ function Creature:setItemOutfit(item, time)
 	return true
 end
 
-function Creature:addSummon(monster)
+function Creature:setSummon(monster)
 	local summon = Monster(monster)
 	if not summon then
 		return false
 	end
 
-	summon:setTarget(nil)
-	summon:setFollowCreature(nil)
-	summon:setDropLoot(false)
-	summon:setSkillLoss(false)
-	summon:setMaster(self)
-
+	summon:setMaster(self, true)
 	return true
 end
 

--- a/data/monster/quests/the_order_of_lion/lion_commander.lua
+++ b/data/monster/quests/the_order_of_lion/lion_commander.lua
@@ -115,7 +115,7 @@ mType.onAppear = function(monster, creature)
 	for i=1, 5 do
 		local sum = Game.createMonster(monster:getType():getSummonList()[math.random(1, #monster:getType():getSummonList())].name, monster:getPosition(), true)
 		if sum then
-			monster:addSummon(sum)
+			monster:setSummon(sum)
 			sum:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			sum:setStorageValue(Storage.TheOrderOfTheLion.Drume.Commander, 1)
 		end

--- a/data/monster/quests/the_order_of_lion/usurper_commander.lua
+++ b/data/monster/quests/the_order_of_lion/usurper_commander.lua
@@ -125,7 +125,7 @@ mType.onAppear = function(monster, creature)
 	for i=1, 5 do
 		sum = Game.createMonster(monster:getType():getSummonList()[math.random(1, #monster:getType():getSummonList())].name, monster:getPosition(), true)
 		if sum then
-			monster:addSummon(sum)
+			monster:setSummon(sum)
 			sum:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			sum:setStorageValue(Storage.TheOrderOfTheLion.Drume.Commander, 1)
 		end

--- a/data/scripts/creaturescripts/quests/ferumbras_ascendant/zamulosh_clone.lua
+++ b/data/scripts/creaturescripts/quests/ferumbras_ascendant/zamulosh_clone.lua
@@ -17,7 +17,7 @@ function zamuloshClone.onThink(creature)
 	for i = 1, #spectators do
 		local master = spectators[i]
 		if master:getMaxHealth() == 300000 and not master:getMaster() then
-			master:addSummon(creature)
+			master:setSummon(creature)
 		end
 	end
 end

--- a/data/scripts/spells/runes/animate_dead_rune.lua
+++ b/data/scripts/spells/runes/animate_dead_rune.lua
@@ -12,7 +12,7 @@ function rune.onCastSpell(player, variant)
 					local summon = Game.createMonster("Skeleton", position, true, true)
 					if summon then
 						corpse:remove()
-						player:addSummon(summon)
+						player:setSummon(summon)
 						position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 						return true
 					end

--- a/data/scripts/spells/runes/convince_creature.lua
+++ b/data/scripts/spells/runes/convince_creature.lua
@@ -32,7 +32,7 @@ function rune.onCastSpell(creature, variant, isHotkey)
 
 	creature:addMana(-manaCost)
 	creature:addManaSpent(manaCost)
-	creature:addSummon(target)
+	creature:setSummon(target)
 	creature:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	return true
 end


### PR DESCRIPTION
Fixed the bug when the player was attacking a creature and summoned, the summon would not attack the creature until the player stopped attacking and attacked again.

Works with: https://github.com/opentibiabr/canary/pull/395

Fixed the icon of creatures that use the "creature:addSummon" function
Added Game::reloadCreature functions
Rework on function "Creature::setMaster", somes functions were centralized within the setMaster, avoiding repetitions:
```cpp
Creature::setTarget
Creature::setFollowCreature
Creature::setDropLoot
Creature::setSkillLoss
```