### PR TITLE
Faceless bane rework

### DIFF
--- a/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
+++ b/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Faceless Bane")
 local monster = {}
 
 monster.description = "a Faceless Bane"
-monster.experience = 30000
+monster.experience = 20000
 monster.outfit = {
 	lookType = 1122,
 	lookHead = 0,
@@ -17,7 +17,7 @@ monster.health = 35000
 monster.maxHealth = 35000
 monster.race = "blood"
 monster.corpse = 30013
-monster.speed = 250
+monster.speed = 500
 monster.manaCost = 0
 
 monster.changeTarget = {
@@ -50,6 +50,11 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = false,
 	canWalkOnPoison = true
+}
+
+monster.events = {
+	"FacelessSummon",
+	"FacelessBaneImmunity"
 }
 
 monster.light = {
@@ -91,7 +96,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-    {name = "melee", type = COMBAT_PHYSICALDAMAGE, interval = 2000, minDamage = 0, maxDamage = -575},
+    {name ="melee", type = COMBAT_PHYSICALDAMAGE, interval = 2000, minDamage = 0, maxDamage = -575},
 	{name ="combat", interval = 2000, chance = 65, type = COMBAT_FIREDAMAGE, minDamage = -350, maxDamage = -500, radius = 3, Effect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = false},
 	{name ="combat", interval = 2000, chance = 45, type = COMBAT_DEATHDAMAGE, minDamage = -335, maxDamage = -450, radius = 4, Effect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = false},
 	{name ="combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -330, maxDamage = -380, length = 7, effect = CONST_ME_EXPLOSIONAREA, target = false},
@@ -104,8 +109,12 @@ monster.defenses = {
 	armor = 10
 }
 
+monster.reflects = {
+	{type = COMBAT_DEATHDAMAGE, percent = 90}
+}
+
 monster.elements = {
-	{type = COMBAT_PHYSICALDAMAGE, percent = 100},
+	{type = COMBAT_PHYSICALDAMAGE, percent = 50},
 	{type = COMBAT_ENERGYDAMAGE, percent = 0},
 	{type = COMBAT_EARTHDAMAGE, percent = 0},
 	{type = COMBAT_FIREDAMAGE, percent = -20},
@@ -114,7 +123,7 @@ monster.elements = {
 	{type = COMBAT_DROWNDAMAGE, percent = 0},
 	{type = COMBAT_ICEDAMAGE, percent = 0},
 	{type = COMBAT_HOLYDAMAGE , percent = 0},
-	{type = COMBAT_DEATHDAMAGE , percent = 99}
+	{type = COMBAT_DEATHDAMAGE , percent = 50}
 }
 
 monster.heals = {

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -1,23 +1,49 @@
 local config = {
+	storage = Storage.ThreatenedDreams.FacelessBaneTime,
+	uniqueId = 1039,
 	bossName = "Faceless Bane",
 	requiredLevel = 250,
 	leverId = 9111,
 	timeToFightAgain = 20, -- In hour
-	timeToDefeatBoss = 20, -- In minutes
-	clearRoomTime = 60, -- In minutes
-	daily = true,
-	centerRoom = Position(33617, 32562, 13),
+	timeToDefeatBoss = 15, -- In minutes
+	daily = true, -- set to false if you want to make the room, without timeToFightAgain timer
+    centerRoom = Position(33617, 32562, 13), -- center of the room
+    fromPos = Position(33608, 32554, 13), -- the upper left corner of the room
+    toPos = Position(33627, 32570, 13), -- the lower right corner of the room
 	playerPositions = {
 		Position(33638, 32562, 13),
 		Position(33639, 32562, 13),
 		Position(33640, 32562, 13),
 		Position(33641, 32562, 13),
 		Position(33642, 32562, 13)
-	},
-	teleportPosition = Position(33617, 32567, 13),
-	bossPosition = Position(33617, 32561, 13),
-	specPos = Position(33618, 32523, 15)
+    },
+	teleportPosition = Position(33617, 32567, 13), -- Players teleport to this position
+	bossPosition = Position(33617, 32561, 13), -- Boss spawn position
+	specPos = Position(33618, 32523, 15),  --kick out position
+    mechanic = true -- Set to false if you don't want to use Faceless Bane's mechanics.
 }
+
+local function isInPos(pos, pos1, pos2)
+    if pos.x >= pos1.x and pos.x <= pos2.x then
+        if pos.y >= pos1.y and pos.y <= pos2.y then
+            if pos.z >= pos1.z and pos.z <= pos2.z then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function playerExitQuest(playerId)
+    local player = Player(playerId)
+    if not player then
+        return
+    end
+    if isInPos(player:getPosition(), config.fromPos, config.toPos) then
+        player:teleportTo(config.specPos)
+    end
+end
 
 local threatenedLever = Action()
 function threatenedLever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
@@ -41,29 +67,27 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 				end
 
 				-- Check participant boss timer
-				if config.daily and participant:getStorageValue(Storage.ThreatenedDreams.FacelessBaneTime) > os.time() then
+				if config.daily and participant:getStorageValue(config.storage) > os.time() then
 					player:getPosition():sendMagicEffect(CONST_ME_POFF)
-					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face Faceless Bane again!")
+					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face ".. config.bossName .." again!")
 					return true
 				end
 				team[#team + 1] = participant
 			end
 		end
 
-		-- Check if a team currently inside the boss room
-		local specs, spec = Game.getSpectators(config.centerRoom, false, false, 14, 14, 13, 13)
-		for i = 1, #specs do
-			spec = specs[i]
-			if spec:isPlayer() then
-				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There's someone fighting with Faceless Bane.")
-				return true
-			end
-			spec:remove()
+	local clearRoom = Game.getSpectators(Position(config.centerRoom), false, false, 10, 10, 10, 10)  --must specify the area to scan depending on the arena size       
+	for index, spectatorcheckface in ipairs(clearRoom) do
+		if spectatorcheckface:isPlayer() then
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Someone is already fighting the boss! You need to wait for your turn.")
+			return false
 		end
-
-		-- One hour for clean the room
-		addEvent(clearRoom, config.clearRoomTime * 60 * 1000, config.centerRoom)
-		Game.createMonster(config.bossName, config.bossPosition)
+	end	
+	for index, removeBoss in ipairs(clearRoom) do
+		if (removeBoss:isMonster()) then
+			removeBoss:remove()
+		end
+	end
 
 		-- Teleport team participants
 		for i = 1, #team do
@@ -71,24 +95,24 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 			team[i]:teleportTo(config.teleportPosition)
 			team[i]:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have ".. config.timeToDefeatBoss .." minutes to kill and loot this boss. Otherwise you will lose that chance and will be kicked out.")
 			-- Assign boss timer
-			team[i]:setStorageValue(Storage.ThreatenedDreams.FacelessBaneTime, os.time() + config.timeToFightAgain * 60 * 60) -- 20 hours
+			team[i]:setStorageValue(config.storage, os.time() + config.timeToFightAgain * 60 * 60) -- 20 hours
 			item:transform(config.leverId)
-			
+				
 				addEvent(function()
-					local specs, spec = Game.getSpectators(config.centerRoom, false, false, 14, 14, 13, 13)
-						for i = 1, #specs do
-							spec = specs[i]
-							if spec:isPlayer() then
-								spec:teleportTo(config.specPos)
-								spec:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-								spec:say("Time out! You were teleported out by strange forces.", TALKTYPE_MONSTER_SAY)
-							end
-						end
+                playerExitQuest(player:getId())
 				end, config.timeToDefeatBoss * 60 * 1000)
+				
 		end
 	end
-	return true
+	Game.createMonster(config.bossName, config.bossPosition)
+    
+    if config.mechanic then
+        Game.setStorageValue(43009, 1)
+        Game.setStorageValue(43010, 1)
+	else Game.setStorageValue(43009, 0)
+		Game.setStorageValue(43010, 0)
+	end
 end
 
-threatenedLever:uid(1039)
+threatenedLever:uid(config.uniqueId)
 threatenedLever:register()

--- a/data/scripts/creaturescripts/monster/faceless_summon.lua
+++ b/data/scripts/creaturescripts/monster/faceless_summon.lua
@@ -1,0 +1,44 @@
+local facelessBaneImmunity = CreatureEvent("FacelessBaneImmunity")
+
+function facelessBaneImmunity.onHealthChange(creature, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
+	if creature and creature:isMonster() then
+        if Game.getStorageValue(43010) >= 1 then
+		    creature:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
+        return true
+        end
+    end
+    return primaryDamage, primaryType, secondaryDamage, secondaryType
+end
+
+facelessBaneImmunity:register()
+
+local FacelessSummon = CreatureEvent("FacelessSummon")
+function FacelessSummon.onThink(creature)
+	if not creature or not creature:isMonster() then
+		return false
+	end
+
+	local spawn = creature:getPosition()
+    if creature:getHealth() <= 3500 then
+		if Game.getStorageValue(43009) == 1 then
+		    Game.createMonster("Faceless Bane", spawn, true, true)
+            Game.createMonster("Ripper Spectre", spawn, true, true)
+            Game.createMonster("Gazer Spectre", spawn, true, true)
+            Game.createMonster("Burster Spectre", spawn, true, true)
+            creature:remove()
+            Game.setStorageValue(43009, 2)
+            Game.setStorageValue(43010, 1)
+        elseif Game.getStorageValue(43009) == 2 then
+            Game.createMonster("Faceless Bane", spawn, true, true)
+            Game.createMonster("Ripper Spectre", spawn, true, true)
+            Game.createMonster("Gazer Spectre", spawn, true, true)
+            Game.createMonster("Burster Spectre", spawn, true, true)
+            creature:remove()
+            Game.setStorageValue(43009, 0)
+            Game.setStorageValue(43010, 1)
+        end
+        return false
+	end
+end
+
+FacelessSummon:register()

--- a/data/scripts/movements/quests/threatened_dreams/reset_faceless.lua
+++ b/data/scripts/movements/quests/threatened_dreams/reset_faceless.lua
@@ -1,0 +1,35 @@
+local function revertAid(position)
+	local tile = Tile(position):getItemById(8284) -- Tile item ID that requires the AID
+	if tile then
+		tile:setAttribute(ITEM_ATTRIBUTE_ACTIONID, 51010) -- Requires AID to be placed on map on all 13 sqm's that are used to activate the boss on global.
+	end
+end
+
+local facelessImmune = MoveEvent()
+function facelessImmune.onStepIn(creature, item, position, fromPosition)
+	local player = creature:getPlayer()
+	if not player then
+		return true
+	end
+
+	local spark = Tile(position):getItemById(8284)
+	if spark then
+        if Game.getStorageValue(43010) < 1 then
+            return true
+        elseif Game.getStorageValue(43010) < 13 then
+            item:getPosition():sendMagicEffect(CONST_ME_ENERGYHIT)
+            item:removeAttribute(ITEM_ATTRIBUTE_ACTIONID)
+            Game.setStorageValue(43010, Game.getStorageValue(43010) +1)
+            addEvent(revertAid, 60 * 1000, position)
+        elseif Game.getStorageValue(43010) == 13 then
+            item:getPosition():sendMagicEffect(CONST_ME_ENERGYHIT)
+            Game.setStorageValue(43010, 0)
+            addEvent(revertAid, 60 * 1000, position)
+        end
+	end
+	return true
+end
+
+facelessImmune:type("stepin")
+facelessImmune:aid(51010)
+facelessImmune:register()


### PR DESCRIPTION
# Description

Reworked the lever script so that Faceless bane wouldn't despawn when another player used the lever while someone else was fighting the boss already. Added the ability to toggle Faceless bane mechanics. Added the scripts required for Faceless Bane's mechanics.

Requires an AID added on the map at the following positions:
Position(33615, 32567, 13)
Position(33613, 32567, 13)
Position(33611, 32563, 13)
Position(33610, 32561, 13)
Position(33611, 32558, 13)
Position(33614, 32557, 13)
Position(33617, 32558, 13)
Position(33620, 32557, 13)
Position(33623, 32558, 13)
Position(33624, 32561, 13)
Position(33623, 32563, 13)
Position(33621, 32567, 13)
Position(33619, 32567, 13)

## Behaviour
### **Actual**

Currently Faceless Bane has no mechanics, and despawns when another player attempts to use the lever while someone is already fighting the boss.

### **Expected**

Faceless bane shouldn't despawn mid fight because someone else tries to use the lever while the room is occupied. Mechanics should work as intended.

## Fixes

Fixes the despawn issue mid fight, and allows the mechanics to be used if desired.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

This has been tested on my local server by several players with no fault.

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 1.3.1
  - Client: 12.86
  - Operating System: Ubuntu 20.2

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
