### PR TITLE
Fix vocation stats for energy ring

### DIFF
--- a/data/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data/scripts/movements/equipment/unscripted_equipments.lua
@@ -16592,7 +16592,13 @@ local items = {
 		-- energy ring
 		itemid = 3088,
 		type = "equip",
-		slot = "ring"
+		slot = "ring",
+		vocation = {
+			{"Knight", true},
+			{"Paladin", true, true},
+			{"Elite Knight"},
+			{"Royal Paladin"}
+		}
 	},
 	{
 		-- energy ring
@@ -16994,7 +17000,13 @@ local items = {
 		-- energy ring
 		itemid = 3051,
 		type = "equip",
-		slot = "ring"
+		slot = "ring",
+		vocation = {
+			{"Knight", true},
+			{"Paladin", true, true},
+			{"Elite Knight"},
+			{"Royal Paladin"}
+		}
 	},
 	{
 		-- energy ring


### PR DESCRIPTION
# Description

Fixing energy ring vocation restrictions.

## Behaviour
### **Actual**

Any character can equip energy ring.

### **Expected**

With this PR, only paladins and knights will be able to equip energy rings.

## Fixes

Resolves #611;

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

To test this PR, take one energy ring, and try to equip with all the vocations. You should be able to equip only with Paladins and Knights.


## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
