### PR TITLE
Fix chest not movable in Kazordoon

### DIFF
--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -268,11 +268,6 @@ ChestUnique = {
 		reward = {{3587, 1}},
 		storage = Storage.Quest.StuddedShield.BananaPremium
 	},
-
-
-	-- [6018] = empyt -- Free slot for a simple chest quest
-
-
 	-- Explorer brooch quest (kazordoon)
 	[6019] = {
 		itemId = 4240,

--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -268,13 +268,11 @@ ChestUnique = {
 		reward = {{3587, 1}},
 		storage = Storage.Quest.StuddedShield.BananaPremium
 	},
-	-- Rope (kazordoon, emperor's cookies quest)
-	[6018] = {
-		itemId = 2472,
-		itemPos = {x = 32604, y = 31908, z = 3},
-		reward = {{3003, 1}},
-		storage = Storage.Quest.EmperorsCookies.RopeReward
-	},
+
+
+	-- [6018] = empyt -- Free slot for a simple chest quest
+
+
 	-- Explorer brooch quest (kazordoon)
 	[6019] = {
 		itemId = 4240,


### PR DESCRIPTION
Chest was not movable due to an unique ID blocking it, under the chest was a lever to open the exit from the mountain.

Fix issue #547 


Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update



## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
