### PR TITLE
Fix teleport to exit of Cults of Tibia in Carlin

### DIFF
--- a/data/scripts/movements/quests/cults_of_tibia/movement-cults-of-carlin-teleport.lua
+++ b/data/scripts/movements/quests/cults_of_tibia/movement-cults-of-carlin-teleport.lua
@@ -1,0 +1,14 @@
+local cultsCarlinTeleportExit = MoveEvent()
+
+function cultsCarlinTeleportExit.onStepIn(creature, item, position, fromPosition)
+	local player = creature:getPlayer()
+	if not player then
+		return false
+	end
+		creature:teleportTo(Position(32403, 31813, 8))
+		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+    return true
+end
+
+cultsCarlinTeleportExit:position({x = 32351, y = 31679, z = 8})
+cultsCarlinTeleportExit:register()


### PR DESCRIPTION
Fix teleport to exit of Cults of Tibia in Carlin

The teleport return to Carlin was not working.
Fix to issue #590 

It was added only the movement script to teleport back.

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update


## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
