### PR TITLE
Update archery rook name

### DIFF
--- a/data/npc/archery_rook.lua
+++ b/data/npc/archery_rook.lua
@@ -1,4 +1,4 @@
-local internalNpcName = "Archery"
+local internalNpcName = "Archery Rook"
 local npcType = Game.createNpcType(internalNpcName)
 local npcConfig = {}
 


### PR DESCRIPTION
Fix for this issue presented in npc custom Archery, royal spear duplicated in store.

![unknown](https://user-images.githubusercontent.com/62149991/172964591-b90c6692-eb3a-4d7c-9339-ab656bc509a2.png)
