### PR TITLE
Fix chest items with charges

### DIFF
--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -147,7 +147,9 @@ function questReward.onUse(player, item, fromPosition, itemEx, toPosition)
 				addItemParams.message = "You have found " .. count .. " " .. itemName
 			elseif ItemType(itemid):getCharges() > 0 then
 				addItemParams.message = "You have found " .. itemArticle .. " " .. itemName
-				addItemParams.weight = getItemWeight(itemid)
+				if not ItemType(itemid):isRune() then
+					addItemParams.weight = getItemWeight(itemid)
+				end
 			else
 				addItemParams.message = "You have found " .. itemArticle .. " " .. itemName
 			end

--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -140,6 +140,10 @@ function questReward.onUse(player, item, fromPosition, itemEx, toPosition)
 				key = setting.isKey
 			}
 
+			if  ItemType(itemid):getCharges() > 0 then
+				addItemParams.weight = getItemWeight(itemid) * 1
+			end
+
 			if count > 1 and ItemType(itemid):isStackable() then
 				if (itemDescriptions.plural) then
 					itemName = itemDescriptions.plural

--- a/data/scripts/actions/system/quest_reward_common.lua
+++ b/data/scripts/actions/system/quest_reward_common.lua
@@ -140,10 +140,6 @@ function questReward.onUse(player, item, fromPosition, itemEx, toPosition)
 				key = setting.isKey
 			}
 
-			if  ItemType(itemid):getCharges() > 0 then
-				addItemParams.weight = getItemWeight(itemid) * 1
-			end
-
 			if count > 1 and ItemType(itemid):isStackable() then
 				if (itemDescriptions.plural) then
 					itemName = itemDescriptions.plural
@@ -151,6 +147,7 @@ function questReward.onUse(player, item, fromPosition, itemEx, toPosition)
 				addItemParams.message = "You have found " .. count .. " " .. itemName
 			elseif ItemType(itemid):getCharges() > 0 then
 				addItemParams.message = "You have found " .. itemArticle .. " " .. itemName
+				addItemParams.weight = getItemWeight(itemid)
 			else
 				addItemParams.message = "You have found " .. itemArticle .. " " .. itemName
 			end


### PR DESCRIPTION
Fix chest items with charges have it`s weight multiplied by charges


# Description

When a reward chest gives an item without a container, it was multiplying the weight of it`s item by the number of charges.
Now with the fix it will consider a single item to calculate the weight.



## Fixes
Fix the issue #646 


Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)


## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
