### PR TITLE
Fix blister ring, sleep shawl, pendulet, ring of souls time counter, monsters loot, items attributes, NPC Cledwyn ids and some ramps attributes

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -43772,31 +43772,47 @@
 	</item>
 	<item id="30342" article="an" name="enchanted sleep shawl">
 		<attribute key="showduration" value="1"/>
+		<attribute key="stopduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
+		<attribute key="transformEquipTo" value="30343"/>
+		<attribute key="absorbpercentphysical" value="7"/>
+		<attribute key="absorbpercentpoison" value="24"/>
+		<attribute key="skilldist" value="3"/>
+		<attribute key="armor" value="3"/>
+		<attribute key="weight" value="430"/>
+	</item>
+	<item id="30343" article="an" name="enchanted sleep shawl">
+		<attribute key="showduration" value="1"/>
+		<attribute key="showAttributes" value="1"/>
+		<attribute key="transformDeEquipTo" value="30342"/>
 		<attribute key="absorbpercentphysical" value="7"/>
 		<attribute key="absorbpercentpoison" value="24"/>
 		<attribute key="skilldist" value="3"/>
 		<attribute key="duration" value="3600"/>
-		<attribute key="decayTo" value="30343"/>
-		<attribute key="armor" value="3"/>
-		<attribute key="weight" value="430"/>
-	</item>
-	<item id="30343" article="a" name="enchanted sleep shawl">
+		<attribute key="decayTo" value="29428"/>
 		<attribute key="armor" value="3"/>
 		<attribute key="weight" value="430"/>
 	</item>
 	<item id="30344" article="an" name="enchanted pendulet">
 		<attribute key="showduration" value="1"/>
+		<attribute key="stopduration" value="1"/>
+		<attribute key="transformEquipTo" value="30345"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentphysical" value="5"/>
 		<attribute key="absorbpercentenergy" value="18"/>
 		<attribute key="skilldist" value="3"/>
-		<attribute key="duration" value="7200"/>
-		<attribute key="decayTo" value="30345"/>
 		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="650"/>
 	</item>
-	<item id="30345" article="a" name="enchanted pendulet">
+	<item id="30345" article="an" name="enchanted pendulet">
+		<attribute key="showduration" value="1"/>
+		<attribute key="showAttributes" value="1"/>
+		<attribute key="transformDeEquipTo" value="30344"/>
+		<attribute key="absorbpercentphysical" value="5"/>
+		<attribute key="absorbpercentenergy" value="18"/>
+		<attribute key="skilldist" value="3"/>
+		<attribute key="duration" value="7200"/>
+		<attribute key="decayTo" value="29429"/>
 		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="650"/>
 	</item>
@@ -43996,6 +44012,9 @@
 		<attribute key="weight" value="500"/>
 	</item>
 	<item id="30403" name="enchanted theurgic amulet">
+		<attribute key="absorbpercentphysical" value="3"/>
+		<attribute key="absorbpercentpoison" value="14"/>
+		<attribute key="magicpoints" value="3"/>
 		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="500"/>
 		<attribute key="transformEquipTo" value="30402" />
@@ -45256,7 +45275,11 @@
 		<attribute key="weight" value="570"/>
 	</item>
 	<item id="31557" article="a" name="blister ring">
-		<attribute key="description" value="This ring is out of magic energy."/>
+		<attribute key="stopduration" value="1"/>
+		<attribute key="showduration" value="1"/>
+		<attribute key="showAttributes" value="1"/>
+		<attribute key="absorbpercentfire" value="6"/>
+		<attribute key="transformequipto" value="31616"/>
 		<attribute key="weight" value="90"/>
 	</item>
 	<item id="31558" article="a" name="red goanna scale">
@@ -45508,8 +45531,8 @@
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentfire" value="6"/>
 		<attribute key="duration" value="3600"/>
-		<attribute key="transformdeequipto" value="31621"/>
-		<attribute key="decayTo" value="31557"/>
+		<attribute key="transformdeequipto" value="31557"/>
+		<attribute key="decayTo" value="31621"/>
 		<attribute key="weight" value="90"/>
 	</item>
 	<item id="31617" name="winged boots">
@@ -45536,11 +45559,6 @@
 	</item>
 	<item id="31621" article="a" name="blister ring">
 		<attribute key="description" value="This ring is out of magic energy"/>
-		<attribute key="stopduration" value="1"/>
-		<attribute key="showduration" value="1"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentfire" value="6"/>
-		<attribute key="transformequipto" value="31616"/>
 		<attribute key="weight" value="90"/>
 	</item>
 	<item id="31622" name="Urmahlullu's tail">
@@ -46767,7 +46785,12 @@
 		</attribute>
 	</item>
 	<item id="32621" article="a" name="ring of souls">
-		<attribute key="description" value="This ring is out of magic energy."/>
+		<attribute key="stopduration" value="1"/>
+		<attribute key="showduration" value="1"/>
+		<attribute key="showAttributes" value="1"/>
+		<attribute key="absorbpercentphysical" value="2"/>
+		<attribute key="absorbpercentlifedrain" value="10"/>
+		<attribute key="transformequipto" value="32635"/>
 		<attribute key="weight" value="80"/>
 	</item>
 	<item id="32622" article="a" name="giant amethyst">
@@ -46840,18 +46863,12 @@
 		<attribute key="absorbpercentphysical" value="2"/>
 		<attribute key="absorbpercentlifedrain" value="10"/>
 		<attribute key="duration" value="7200"/>
-		<attribute key="transformdeequipto" value="32636"/>
-		<attribute key="decayTo" value="32621"/>
+		<attribute key="transformdeequipto" value="32621"/>
+		<attribute key="decayTo" value="32636"/>
 		<attribute key="weight" value="80"/>
 	</item>
 	<item id="32636" article="a" name="ring of souls">
 		<attribute key="description" value="This ring is out of magic energy"/>
-		<attribute key="stopduration" value="1"/>
-		<attribute key="showduration" value="1"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentphysical" value="2"/>
-		<attribute key="absorbpercentlifedrain" value="10"/>
-		<attribute key="transformequipto" value="32635"/>
 		<attribute key="weight" value="80"/>
 	</item>
 	<item id="32637" article="a" name="unknow"/>

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -26039,7 +26039,10 @@
 	<item fromid="16483" toid="16497" article="a" name="grimy wooden plank"/>
 	<item fromid="16498" toid="16571" name="RESERVED SPRITE"/>
 	<item id="16572" article="a" name="wooden treadmill"/>
-	<item fromid="16573" toid="16575" article="a" name="wooden ramp"/>
+	<item id="16573" article="a" name="wooden ramp">
+		<attribute key="floorchange" value="north"/>
+	</item>
+	<item fromid="16574" toid="16575" article="a" name="wooden ramp"/>
 	<item fromid="16576" toid="16577" article="a" name="wooden planks"/>
 	<item id="16578" name="nails"/>
 	<item fromid="16579" toid="16580" article="a" name="wooden planks"/>
@@ -26181,7 +26184,11 @@
 	</item>
 	<item id="17231" article="a" name="wooden scaffolding"/>
 	<item fromid="17232" toid="17234" article="a" name="small wooden fence"/>
-	<item fromid="17235" toid="17237" article="a" name="wooden ramp"/>
+	<item id="17235" article="a" name="wooden ramp"/>
+	<item id="17236" article="a" name="wooden ramp">
+		<attribute key="floorchange" value="north"/>
+	</item>
+	<item id="17237" article="a" name="wooden ramp"/>
 	<item id="17238" name="muddy floor">
 		<attribute key="description" value="There is a hole in the ceiling."/>
 	</item>

--- a/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
+++ b/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
@@ -87,7 +87,7 @@ monster.loot = {
 	{name = "ectoplasmic shield", chance = 600},
 	{name = "book backpack", chance = 550},
 	{name = "spirit guide", chance = 530},
-	{id = 30345, chance = 500}, -- enchanted pendulet
+	{id = 30344, chance = 500}, -- enchanted pendulet
 }
 
 monster.attacks = {

--- a/data/monster/quests/the_dream_courts/bosses/the_nightmare_beast.lua
+++ b/data/monster/quests/the_dream_courts/bosses/the_nightmare_beast.lua
@@ -107,7 +107,7 @@ monster.loot = {
 	{id = 3341, chance = 2880}, -- arcane staff
 	{name = "giant ruby", chance = 2880},
 	{name = "abyss hammer", chance = 2160},
-	{id = 30343, chance = 2160}, -- enchanted sleep shawl
+	{id = 30342, chance = 2160}, -- enchanted sleep shawl
 	{name = "unicorn figurine", chance = 1000}
 }
 

--- a/data/npc/cledwyn.lua
+++ b/data/npc/cledwyn.lua
@@ -100,11 +100,11 @@ end
 local charge = {}
 
 local chargeItem = {
-	['pendulet'] = {noChargeID = 29429, ChargeID = 30345},
-	['sleep shawl'] = {noChargeID = 29428, ChargeID = 30343},
-	['blister ring'] = {noChargeID = 31557, ChargeID = 31621},
+	['pendulet'] = {noChargeID = 29429, ChargeID = 30344},
+	['sleep shawl'] = {noChargeID = 29428, ChargeID = 30342},
+	['blister ring'] = {noChargeID = 31621, ChargeID = 31557},
 	['theurgic amulet'] = {noChargeID = 30401, ChargeID = 30403},
-	['ring of souls'] = {noChargeID = 32621, ChargeID = 32636}
+	['ring of souls'] = {noChargeID = 32636, ChargeID = 32621}
 }
 
 local function creatureSayCallback(npc, creature, type, message)
@@ -132,10 +132,10 @@ local function creatureSayCallback(npc, creature, type, message)
 		npcHandler:say({"Here's the deal, " .. player:getName() .. ". For 100 of your silver tokens, I can offer you some first-class torso armor. These armors provide a solid boost to your main attack skill, as well as ...",
 		"some elemental protection of your choice! I also sell a magic shield potion for one silver token. So these are my offers."}, npc, creature)
 	elseif MsgContains(message, 'enchant') then
-		npcHandler:say("The following items can be enchanted: {pendulet}, {sleep shawl}, {blister ring}, {theurgic amulet}. Make you choice!", npc, creature)
+		npcHandler:say("The following items can be enchanted: {pendulet}, {sleep shawl}, {blister ring}, {theurgic amulet}, {ring of souls}. Make you choice!", npc, creature)
 		npcHandler:setTopic(playerId, 1)
-	elseif isInArray({'pendulet', 'sleep shawl', 'blister ring', 'theurgic amulet'}, message:lower()) and npcHandler:getTopic(playerId) == 1 then
-		npcHandler:say("Should I enchant the item pendulet for 2 ".. ItemType(npc:getCurrency()):getPluralName():lower() .."?", npc, creature)
+	elseif isInArray({'pendulet', 'sleep shawl', 'blister ring', 'theurgic amulet', 'ring of souls'}, message:lower()) and npcHandler:getTopic(playerId) == 1 then
+		npcHandler:say("Should I enchant the item " .. message .. " for 2 ".. ItemType(npc:getCurrency()):getPluralName():lower() .."?", npc, creature)
 		charge = message:lower()
 		npcHandler:setTopic(playerId, 2)
 	elseif npcHandler:getTopic(playerId) == 2 then

--- a/data/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data/scripts/movements/equipment/unscripted_equipments.lua
@@ -2012,7 +2012,7 @@ local items = {
 		slot = "feet"
 	},
 	{
-		-- pendulet
+		-- enchanted pendulet
 		itemid = 30345,
 		type = "equip",
 		slot = "necklace",
@@ -2023,7 +2023,7 @@ local items = {
 		}
 	},
 	{
-		-- pendulet
+		-- enchanted pendulet
 		itemid = 30345,
 		type = "deequip",
 		slot = "necklace",
@@ -2048,7 +2048,7 @@ local items = {
 		level = 180
 	},
 	{
-		-- sleep shawl
+		-- enchanted sleep shawl
 		itemid = 30343,
 		type = "equip",
 		slot = "necklace",
@@ -2059,7 +2059,7 @@ local items = {
 		}
 	},
 	{
-		-- sleep shawl
+		-- enchanted sleep shawl
 		itemid = 30343,
 		type = "deequip",
 		slot = "necklace",
@@ -2131,6 +2131,42 @@ local items = {
 		itemid = 29430,
 		type = "deequip",
 		slot = "shield",
+		level = 180
+	},
+	{
+		-- pendulet
+		itemid = 29429,
+		type = "equip",
+		slot = "necklace",
+		level = 180,
+		vocation = {
+			{"Paladin", true},
+			{"Royal Paladin"}
+		}
+	},
+	{
+		-- pendulet
+		itemid = 29429,
+		type = "deequip",
+		slot = "necklace",
+		level = 180
+	},
+	{
+		-- sleep shawl
+		itemid = 29428,
+		type = "equip",
+		slot = "necklace",
+		level = 180,
+		vocation = {
+			{"Paladin", true},
+			{"Royal Paladin"}
+		}
+	},
+	{
+		-- sleep shawl
+		itemid = 29428,
+		type = "deequip",
+		slot = "necklace",
 		level = 180
 	},
 	{


### PR DESCRIPTION
# Description

- Fixes issue that time was being counted even when sleep shawl and enchanted pendulet were unequipped;
- Fix IDs of equipped/unequipped and used items according to tibia assets (blister ring, sleep shawl, pendulet ad ring of souls);
- Fix IDs from those items on monster's loot.

- Adjust on ramps attributes for new map
