### PR TITLE
fix gaffir wall

### DIFF
--- a/data/scripts/movements/quests/grave_danger/firewall_gaffir.lua
+++ b/data/scripts/movements/quests/grave_danger/firewall_gaffir.lua
@@ -1,0 +1,47 @@
+local above = {[32021] = 5062}
+local outside = {[5062] = 32021}
+
+-- onStepIn
+local gaffirwall = MoveEvent()
+
+function gaffirwall.onStepIn(creature, item, position, fromPosition)
+	if not above[item.itemid] then
+		return true
+	end
+
+	local player = creature:getPlayer()
+	if not player or player:isInGhostMode() then
+		return true
+	end
+	item:transform(above[item.itemid])
+end
+
+gaffirwall:type("stepin")
+
+for index, value in pairs(above) do
+	gaffirwall:id(index)
+end
+gaffirwall:register()
+
+gaffirwall = MoveEvent()
+
+function gaffirwall.onStepOut(creature, item, position, fromPosition)
+	if not outside[item.itemid] then
+		return false
+	end
+
+	local player = creature:getPlayer()
+	if not player or player:isInGhostMode() then
+		return true
+	end
+
+	item:transform(outside[item.itemid])
+	player:setSpecialContainersAvailable(false, false)
+	return true
+end
+
+gaffirwall:type("stepout")
+for index, value in pairs(outside) do
+	gaffirwall:id(index)
+end
+gaffirwall:register()


### PR DESCRIPTION
# Description

Fix burning wall where creatures could go inside (Gaffir and Custodian - Cobra Bastion)

## Behaviour
### **Actual**

Creatures can move back and forth on the gaffir/custodian's burning wall

### **Expected**

With this PR, only players can go through the burning wall

## Fixes

Resolves #640;

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

To test, the player must move to Gaffir's room (Cobra Bastion) and try to lure the creatures between the burning wall.

  - [x] Test A [Gaffir](https://cdn.discordapp.com/attachments/965214901566070826/991466943674601482/Gaffir_Parede.gif)
  - [ ] Test B

**Test Configuration**:

  - Server Version: otservbr-global
  - Client: 12.87.12055
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
