### PR TITLE
Fix gaffir burning wall

### DIFF
--- a/data/scripts/movements/quests/grave_danger/firewall_gaffir.lua
+++ b/data/scripts/movements/quests/grave_danger/firewall_gaffir.lua
@@ -1,0 +1,47 @@
+local above = {[32021] = 5062}
+local outside = {[5062] = 32021}
+
+-- onStepIn
+local gaffirwall = MoveEvent()
+
+function gaffirwall.onStepIn(creature, item, position, fromPosition)
+	if not above[item.itemid] then
+		return true
+	end
+
+	local player = creature:getPlayer()
+	if not player or player:isInGhostMode() then
+		return true
+	end
+	item:transform(above[item.itemid])
+end
+
+gaffirwall:type("stepin")
+
+for index, value in pairs(above) do
+	gaffirwall:id(index)
+end
+gaffirwall:register()
+
+gaffirwall = MoveEvent()
+
+function gaffirwall.onStepOut(creature, item, position, fromPosition)
+	if not outside[item.itemid] then
+		return false
+	end
+
+	local player = creature:getPlayer()
+	if not player or player:isInGhostMode() then
+		return true
+	end
+
+	item:transform(outside[item.itemid])
+	player:setSpecialContainersAvailable(false, false)
+	return true
+end
+
+gaffirwall:type("stepout")
+for index, value in pairs(outside) do
+	gaffirwall:id(index)
+end
+gaffirwall:register()


### PR DESCRIPTION
# Description

Change in the map Burning Wall ID 5062 to ID 32021 in the coordenates
X= 33389, Y = 32674, Z= 4 and
X=33386, Y= FROM 32823 TO 32829, Z=8

Chance name item in items.xml

	<item id="32021" name="burning wall"/>
	<item fromid="32022" toid="32035" name="addled egg">
		<attribute key="weight" value="100"/>
	</item>

## Behaviour
### **Actual**

Creatures pass through the burning wall in the gaffir's room.

### **Expected**

With the change of id's on the map and the code, the creatures stopped passing and the players will be able to pass and use spells on top of the wall according to the global.

## Fixes

Resolves #640 

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

[GAFFIR](https://media.discordapp.net/attachments/965214901566070826/991466943674601482/Gaffir_Parede.gif)
  - [X] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: otservbr-global
  - Client: 12.87.12055
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have added tests that prove my fix is effective or that my feature works
