### PR TITLE
Removed attribute from rechargeable amulets and rings to prevent duplicated bonus, changed convince creature rune logic to work in inquisition quest

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -43803,12 +43803,7 @@
 	<item id="30342" article="an" name="enchanted sleep shawl">
 		<attribute key="showduration" value="1"/>
 		<attribute key="stopduration" value="1"/>
-		<attribute key="showAttributes" value="1"/>
 		<attribute key="transformEquipTo" value="30343"/>
-		<attribute key="absorbpercentphysical" value="7"/>
-		<attribute key="absorbpercentpoison" value="24"/>
-		<attribute key="skilldist" value="3"/>
-		<attribute key="armor" value="3"/>
 		<attribute key="weight" value="430"/>
 	</item>
 	<item id="30343" article="an" name="enchanted sleep shawl">
@@ -43827,11 +43822,6 @@
 		<attribute key="showduration" value="1"/>
 		<attribute key="stopduration" value="1"/>
 		<attribute key="transformEquipTo" value="30345"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentphysical" value="5"/>
-		<attribute key="absorbpercentenergy" value="18"/>
-		<attribute key="skilldist" value="3"/>
-		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="650"/>
 	</item>
 	<item id="30345" article="an" name="enchanted pendulet">
@@ -44042,10 +44032,6 @@
 		<attribute key="weight" value="500"/>
 	</item>
 	<item id="30403" name="enchanted theurgic amulet">
-		<attribute key="absorbpercentphysical" value="3"/>
-		<attribute key="absorbpercentpoison" value="14"/>
-		<attribute key="magicpoints" value="3"/>
-		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="500"/>
 		<attribute key="transformEquipTo" value="30402" />
 		<attribute key="stopduration" value="1" />
@@ -45307,8 +45293,6 @@
 	<item id="31557" article="a" name="blister ring">
 		<attribute key="stopduration" value="1"/>
 		<attribute key="showduration" value="1"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentfire" value="6"/>
 		<attribute key="transformequipto" value="31616"/>
 		<attribute key="weight" value="90"/>
 	</item>
@@ -46818,9 +46802,6 @@
 	<item id="32621" article="a" name="ring of souls">
 		<attribute key="stopduration" value="1"/>
 		<attribute key="showduration" value="1"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentphysical" value="2"/>
-		<attribute key="absorbpercentlifedrain" value="10"/>
 		<attribute key="transformequipto" value="32635"/>
 		<attribute key="weight" value="80"/>
 	</item>

--- a/data/scripts/spells/runes/convince_creature.lua
+++ b/data/scripts/spells/runes/convince_creature.lua
@@ -10,7 +10,7 @@ function rune.onCastSpell(creature, variant, isHotkey)
 
 	local monsterType = target:getType()
 	if not creature:hasFlag(PlayerFlag_CanConvinceAll) then
-		if not monsterType:isConvinceable() or target:getMaster() then
+		if not monsterType:isConvinceable() or (target:getMaster() and target:getMaster():getName():lower() ~= "a carved stone tile") then
 			creature:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 			creature:getPosition():sendMagicEffect(CONST_ME_POFF)
 			return false


### PR DESCRIPTION
# Description

- Removed the attribute bonus tags from cledwyn's rechargeable amulets and rings to prevent duplicated bonus.
A fix should be done on the source at the future to correct this, but meanwhile, this attributes should be removed.

- Changed convince creature rune logic, so it can work on dreadbeasts in Inquisition Quest.

