### PR TITLE
Fix npcs walkaway logic

### DIFF
--- a/data/npclib/npc.lua
+++ b/data/npclib/npc.lua
@@ -53,13 +53,13 @@ function Npc:sayWithDelay(npcId, text, messageType, delay, eventDelay, player)
 	eventDelay.event = addEvent(sayFunction, delay < 1 and 1000 or delay, npcId, text, messageType, eventDelay, player)
 end
 
-function SayEvent(npcId, playerId, messageDelayed, npcHandler)
-	local player = Player(playerId)
+function SayEvent(npcId, playerId, messageDelayed, npcHandler, textType)
 	local npc = Npc(npcId)
 	if not npc then
 		return Spdlog.error("[NpcHandler:say] - Npc parameter is missing, nil or not found")
 	end
 
+	local player = Player(playerId)
 	if not player then
 		return Spdlog.error("[NpcHandler:say] - Player parameter is missing, nil or not found")
 	end

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -390,7 +390,7 @@ if NpcHandler == nil then
 		local callback = self:getCallback(CALLBACK_ON_DISAPPEAR)
 		if callback == nil or callback(npc, player) then
 			if self:processModuleCallback(CALLBACK_ON_DISAPPEAR, npc, player) then
-				self:unGreet(npc, player)
+				self:onWalkAway(npc, player)
 			end
 		end
 	end
@@ -526,12 +526,12 @@ if NpcHandler == nil then
 				local message_female = self:parseMessage(msg_female, parseInfo)
 				if message_female ~= message_male then
 					if playerSex == PLAYERSEX_FEMALE then
-						self:say(message_female, npc, player, true, TALKTYPE_SAY)
+						npc:sayWithDelay(npc:getId(), message_female, TALKTYPE_SAY, 1000, self.eventDelayedSay)
 					else
-						self:say(message_male, npc, player, true, TALKTYPE_SAY)
+						npc:sayWithDelay(npc:getId(), message_male, TALKTYPE_SAY, 1000, self.eventDelayedSay)
 					end
 				elseif message ~= "" then
-					self:say(message, npc, player, true, TALKTYPE_SAY)
+					npc:sayWithDelay(npc:getId(), message, TALKTYPE_SAY, 1000, self.eventDelayedSay)
 				end
 				self:resetNpc(player)
 				self:removeInteraction(npc, player)
@@ -604,7 +604,7 @@ if NpcHandler == nil then
 		end
 
 		stopEvent(self.eventSay[playerId])
-		self.eventSay[playerId] = addEvent(SayEvent, self.talkDelayTimeForOutgoingMessages * 1000, npc:getId(), player:getId(), message, self)
+		self.eventSay[playerId] = addEvent(SayEvent, self.talkDelayTimeForOutgoingMessages * 1000, npc:getId(), player:getId(), message, self, textType)
 	end
 
 	-- sendMessages(msg, messagesTable, npc, player, useDelay(true or false), delay)

--- a/data/npclib/npc_system/npc_handler.lua
+++ b/data/npclib/npc_system/npc_handler.lua
@@ -526,12 +526,12 @@ if NpcHandler == nil then
 				local message_female = self:parseMessage(msg_female, parseInfo)
 				if message_female ~= message_male then
 					if playerSex == PLAYERSEX_FEMALE then
-						npc:sayWithDelay(npc:getId(), message_female, TALKTYPE_SAY, 1000, self.eventDelayedSay)
+						npc:sayWithDelay(npc:getId(), message_female, TALKTYPE_SAY, self.talkDelay, self.eventDelayedSay)
 					else
-						npc:sayWithDelay(npc:getId(), message_male, TALKTYPE_SAY, 1000, self.eventDelayedSay)
+						npc:sayWithDelay(npc:getId(), message_male, TALKTYPE_SAY, self.talkDelay, self.eventDelayedSay)
 					end
 				elseif message ~= "" then
-					npc:sayWithDelay(npc:getId(), message, TALKTYPE_SAY, 1000, self.eventDelayedSay)
+					npc:sayWithDelay(npc:getId(), message, TALKTYPE_SAY, self.talkDelay, self.eventDelayedSay)
 				end
 				self:resetNpc(player)
 				self:removeInteraction(npc, player)


### PR DESCRIPTION
Npcs will now speak in the default channel instead of speaking in the npc channel when occurs the walkaway or the creature disappears