### PR TITLE
Fix redskull and blackskull droploot

### DIFF
--- a/data/modules/scripts/blessings/blessings.lua
+++ b/data/modules/scripts/blessings/blessings.lua
@@ -277,7 +277,7 @@ Blessings.DropLoot = function(player, corpse, chance, skulled)
 		local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
 		local inboxsize = inbox:getSize() - 1
 		for i = 0, inboxsize do
-			inbox:getItem(i):destroy()
+			inbox:getItem(i):remove()
 		end
 	end
 end

--- a/data/modules/scripts/blessings/blessings.lua
+++ b/data/modules/scripts/blessings/blessings.lua
@@ -263,7 +263,7 @@ Blessings.DropLoot = function(player, corpse, chance, skulled)
 		if item then
 			local thisChance = chance
 			local thisRandom = math.random(100*multiplier)
-			if not item:isinbox() then
+			if not item:isContainer() then
 				thisChance = chance/10
 			end
 			Blessings.DebugPrint(thisChance/multiplier .. "%" .. " | thisRandom "..thisRandom/multiplier.."%", "DropLoot item "..item:getName() .. " |")

--- a/data/modules/scripts/blessings/blessings.lua
+++ b/data/modules/scripts/blessings/blessings.lua
@@ -263,7 +263,7 @@ Blessings.DropLoot = function(player, corpse, chance, skulled)
 		if item then
 			local thisChance = chance
 			local thisRandom = math.random(100*multiplier)
-			if not item:isContainer() then
+			if not item:isinbox() then
 				thisChance = chance/10
 			end
 			Blessings.DebugPrint(thisChance/multiplier .. "%" .. " | thisRandom "..thisRandom/multiplier.."%", "DropLoot item "..item:getName() .. " |")
@@ -275,9 +275,22 @@ Blessings.DropLoot = function(player, corpse, chance, skulled)
 	end
 	if skulled and Blessings.Config.SkulledDeathLoseStoreItem then
 		local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-		local inboxsize = inbox:getSize() - 1
-		for i = 0, inboxsize do
-			inbox:getItem(i):remove()
+		local toBeDeleted = {}
+		if inbox and inbox:getSize() > 0 then
+			for i = 0, inbox:getSize() do
+				local item = inbox:getItem(i)
+				if item then
+					toBeDeleted[#toBeDeleted + 1] = item.uid
+				end
+			end
+			if #toBeDeleted > 0 then
+				for i, v in pairs(toBeDeleted) do
+					local item = Item(v)
+					if item then
+						item:remove()
+					end
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
# Description

Fix redskull and blackskull droploot.

## Behaviour
### **Actual**

When killing a player with red skull or black skull, it shows an error on distro.

### **Expected**

When killing a player with red skull or black skull, it shows no error on distro.

## Fixes

#745

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  
## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
