### PR TITLE
Fix exercise weapons and dummy

### DIFF
--- a/data/lib/tables/exercise_training.lua
+++ b/data/lib/tables/exercise_training.lua
@@ -94,7 +94,7 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 	end
 
 	local isMagic = ExerciseWeaponsTable[weaponId].skill == SKILL_MAGLEVEL
-	local bonusDummy = table.contains(HouseDummies, weaponId) or nil
+	local bonusDummy = table.contains(HouseDummies, dummyId) or nil
 
 	if bonusDummy then bonusDummy = 1.1 else bonusDummy = 1 end
 

--- a/data/scripts/actions/other/exercise_training.lua
+++ b/data/scripts/actions/other/exercise_training.lua
@@ -22,9 +22,15 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 			return true
 		end
 
+		local playerHouse = player:getTile():getHouse()
 		local targetPos = target:getPosition()
+		local targetHouse = Tile(targetPos):getHouse()
 
 		if table.contains(HouseDummies, targetId) then
+			if playerHouse ~= targetHouse then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You must be inside the house to use this dummy.")
+				return true
+			end
 			local playersOnDummy = 0
 			for _, playerTraining in pairs(onExerciseTraining) do
 				if playerTraining.dummyPos == targetPos then


### PR DESCRIPTION
# Description

Fix Exercise Weapons and Dummy Bugs

## Behaviour
### **Actual**

You can use the Dummy even if not in the house
Dont receive any bonus for using dummy in a house

### **Expected**

Can only use a House Dummy if you are inside the same house of Dummy
Receive a 10% bonus when using dummy on a house

## Fixes

#362 
#706 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
