### PR TITLE
Rework Gaz'haragoth summon spell and Minion of Gaz'haragoth

### DIFF
--- a/data/actions/roshamuul/strange_vortex_tp.lua
+++ b/data/actions/roshamuul/strange_vortex_tp.lua
@@ -1,0 +1,19 @@
+local nightmarePosition = Position(33542, 32421, 15)
+
+local nightmareVortex = MoveEvent()
+
+function nightmareVortex.onStepIn(creature, item, position, fromPosition)
+    local player = creature:getPlayer()
+    if not player then
+        return false
+    end
+
+    player:teleportTo(nightmarePosition)
+    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have been trapped in a nightmare.")
+
+    return true
+end
+
+nightmareVortex:type("stepin")
+nightmareVortex:aid(33542)
+nightmareVortex:register()

--- a/data/creaturescripts/monster/minion_gaz_haragoth_vortex.lua
+++ b/data/creaturescripts/monster/minion_gaz_haragoth_vortex.lua
@@ -1,0 +1,26 @@
+local function removeTeleport(position)
+    local teleportItem = Tile(position):getItemById(20121)
+    if teleportItem then
+        teleportItem:remove()
+    end
+end
+
+local minionDeath = CreatureEvent("MinionGazDeath")
+
+function minionDeath.onDeath(creature, corpse, killer, mostDamageKiller, unjustified, mostDamageUnjustified)
+    local targetMonster = creature:getMonster()
+    if not targetMonster then
+        return true
+    end
+
+    local deathPosition = creature:getPosition()
+    local item = Game.createItem(20121, 1, deathPosition)
+
+    item:setActionId(33542)
+
+    addEvent(removeTeleport, 1 * 60 * 1000, deathPosition)
+
+    return true
+end
+
+minionDeath:register()

--- a/data/monster/quests/roshamuul/gaz'haragoth.lua
+++ b/data/monster/quests/roshamuul/gaz'haragoth.lua
@@ -62,10 +62,6 @@ monster.light = {
 }
 
 monster.summon = {
-	maxSummons = 3,
-	summons = {
-		{name = "Minion of Gaz'haragoth", chance = 33, interval = 4000, count = 3}
-	}
 }
 
 monster.voices = {
@@ -148,7 +144,8 @@ monster.attacks = {
 	{name ="combat", interval = 2500, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -200, maxDamage = -480, range = 7, radius = 5, effect = CONST_ME_MAGIC_GREEN, target = false},
 	{name ="gaz'haragoth iceball", interval = 2000, chance = 24, minDamage = -1000, maxDamage = -1000, target = false},
 	{name ="gaz'haragoth death", interval = 4000, chance = 6, target = false},
-	{name ="gaz'haragoth paralyze", interval = 2000, chance = 12, target = false}
+	{name ="gaz'haragoth paralyze", interval = 2000, chance = 12, target = false},
+	{name ="gaz'haragoth summon", interval = 1000, chance = 100, target = false}
 }
 
 monster.defenses = {

--- a/data/monster/quests/roshamuul/minion_of_gaz'haragoth.lua
+++ b/data/monster/quests/roshamuul/minion_of_gaz'haragoth.lua
@@ -15,8 +15,8 @@ monster.outfit = {
 
 monster.health = 5500
 monster.maxHealth = 5500
-monster.race = "blood"
-monster.corpse = 20215
+monster.race = "undead"
+monster.corpse = 0
 monster.speed = 330
 monster.manaCost = 0
 
@@ -52,6 +52,10 @@ monster.flags = {
 	canWalkOnPoison = false
 }
 
+monster.events = {
+	"MinionGazDeath"
+}
+
 monster.light = {
 	level = 0,
 	color = 0
@@ -77,20 +81,20 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{type = COMBAT_PHYSICALDAMAGE, percent = 0},
-	{type = COMBAT_ENERGYDAMAGE, percent = 100},
-	{type = COMBAT_EARTHDAMAGE, percent = 100},
-	{type = COMBAT_FIREDAMAGE, percent = -10},
-	{type = COMBAT_LIFEDRAIN, percent = 100},
+	{type = COMBAT_PHYSICALDAMAGE, percent = 1},
+	{type = COMBAT_ENERGYDAMAGE, percent = 15},
+	{type = COMBAT_EARTHDAMAGE, percent = 0},
+	{type = COMBAT_FIREDAMAGE, percent = -100},
+	{type = COMBAT_LIFEDRAIN, percent = 0},
 	{type = COMBAT_MANADRAIN, percent = 0},
 	{type = COMBAT_DROWNDAMAGE, percent = 0},
-	{type = COMBAT_ICEDAMAGE, percent = -10},
-	{type = COMBAT_HOLYDAMAGE , percent = 0},
+	{type = COMBAT_ICEDAMAGE, percent = 0},
+	{type = COMBAT_HOLYDAMAGE , percent = 30},
 	{type = COMBAT_DEATHDAMAGE , percent = 0}
 }
 
 monster.immunities = {
-	{type = "paralyze", condition = true},
+	{type = "paralyze", condition = false},
 	{type = "outfit", condition = false},
 	{type = "invisible", condition = true},
 	{type = "bleed", condition = false}

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -1,31 +1,44 @@
+dofile("data/scripts/spells/monster/gaz_functions.lua")
+
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, var)
-local t, spectator = Game.getSpectators(creature:getPosition(), false, false, 5, 5, 5, 5)
+    local t, spectator = Game.getSpectators(creature:getPosition(), false, false, 25, 25, 25, 25)
     local check = 0
     if #t ~= nil then
         for i = 1, #t do
-		spectator = t[i]
-            if spectator:getName() == "Minion Of Gaz'haragoth" then
-               check = check + 1
+            spectator = t[i]
+            if spectator:getName() == "Minion of Gaz'haragoth" then
+                check = check + 1
             end
         end
     end
-	local hp = (creature:getHealth()/creature:getMaxHealth())* 100
-	if ((check < 2) and hp <= 95) or ((check < 4) and hp <= 75) or ((check < 6) and hp <= 55) or ((check < 10) and hp <= 35) then
-		for j = 1, 5 do
-			creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-		end
-		for k = 1, 2 do
-			local monster = Game.createMonster("minion of gaz'haragoth", creature:getPosition(), true, false)
-			if not monster then
-				return
-			end
-			creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
-		end
-		else
-	end
-return true
+
+    if (check >= GazVariables.MaxSummons) then
+        return false
+    else
+        if (check < GazVariables.MinionsNow) then
+            for i = 1, (GazVariables.MinionsNow - check) do
+                local monster = Game.createMonster("minion of gaz'haragoth", creature:getPosition(), true, false)
+            end
+            creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
+            if not monster then
+                return
+            end
+            creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
+        else
+            if (math.random(0, 100) < 25) then
+                local monster = Game.createMonster("minion of gaz'haragoth", creature:getPosition(), true, false)
+                creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
+                if not monster then
+                    return
+                end
+                creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
+                GazVariables.MinionsNow = GazVariables.MinionsNow + 1
+            end
+        end
+    end
+    return true
 end
 
 spell:name("gaz'haragoth summon")

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -18,11 +18,12 @@ function spell.onCastSpell(creature, var)
         return false
     else
         if (check < GazVariables.MinionsNow) then
+            local monster
             for i = 1, (GazVariables.MinionsNow - check) do
-                local monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
+                monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
             end
             creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-             if monster then
+            if monster then
                 creature:setSummon(monster)
             end
             creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -21,8 +21,8 @@ function spell.onCastSpell(creature, var)
             local monster
             for i = 1, (GazVariables.MinionsNow - check) do
                 monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
+								creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
             end
-            creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
             if monster then
                 creature:setSummon(monster)
             end

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -19,19 +19,19 @@ function spell.onCastSpell(creature, var)
     else
         if (check < GazVariables.MinionsNow) then
             for i = 1, (GazVariables.MinionsNow - check) do
-                local monster = Game.createMonster("minion of gaz'haragoth", creature:getPosition(), true, false)
+                local monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
             end
             creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-            if not monster then
-                return
+             if monster then
+                creature:setSummon(monster)
             end
             creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
         else
             if (math.random(0, 100) < 25) then
-                local monster = Game.createMonster("minion of gaz'haragoth", creature:getPosition(), true, false)
+                local monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
                 creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-                if not monster then
-                    return
+                if monster then
+                    creature:setSummon(monster)
                 end
                 creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
                 GazVariables.MinionsNow = GazVariables.MinionsNow + 1

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -18,13 +18,13 @@ function spell.onCastSpell(creature, var)
         return false
     else
         if (check < GazVariables.MinionsNow) then
-            local monster
+	    local monster
             for i = 1, (GazVariables.MinionsNow - check) do
                 monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
-								creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-            end
-            if monster then
-                creature:setSummon(monster)
+		creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
+		if monster then
+                    creature:setSummon(monster)
+                end
             end
             creature:getPosition():sendMagicEffect(CONST_ME_SOUND_RED)
         else

--- a/data/scripts/spells/monster/gaz'haragoth_summon.lua
+++ b/data/scripts/spells/monster/gaz'haragoth_summon.lua
@@ -18,11 +18,11 @@ function spell.onCastSpell(creature, var)
         return false
     else
         if (check < GazVariables.MinionsNow) then
-	    local monster
+            local monster
             for i = 1, (GazVariables.MinionsNow - check) do
                 monster = Game.createMonster("Minion of Gaz'haragoth", creature:getPosition(), true, false)
-		creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
-		if monster then
+                creature:say("Minions! Follow my call!", TALKTYPE_ORANGE_1)
+                if monster then
                     creature:setSummon(monster)
                 end
             end

--- a/data/scripts/spells/monster/gaz_functions.lua
+++ b/data/scripts/spells/monster/gaz_functions.lua
@@ -1,0 +1,4 @@
+GazVariables = {
+    MinionsNow = 2,
+    MaxSummons = 7
+}


### PR DESCRIPTION
# Description

Rework Gaz'haragoth summon spell and Minion of Gaz'haragoth, based on [Minion of Gaz'Haragoth](https://www.tibiawiki.com.br/wiki/Minion_of_Gaz%27Haragoth). And needs a little map change.

## Behaviour
### **Actual**

Gaz'haragoth can only summon 3 Minion of Gaz'Haragoth, and Minion of Gaz'Haragoth doesn't transform into Strange Vortex.

### **Expected**

Gaz'haragoth's Summon Spell now works similar to Global and Minion of Gaz'Haragoth as well.

## Fixes

#699 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [X] New feature (non-breaking change which adds functionality)

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
