### PR TITLE
Fix Mortimer dialogue loop when delivering the pickaxe

### DIFF
--- a/data/npc/mortimer.lua
+++ b/data/npc/mortimer.lua
@@ -400,8 +400,8 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:setStorageValue(Storage.ExplorerSociety.QuestLine, 1)
 		elseif npcHandler:getTopic(playerId) == 3 then
 			if player:removeItem(4845, 1) then
-				player:setStorageValue(Storage.ExplorerSociety.JoiningTheExplorers, 4)
-				player:setStorageValue(Storage.ExplorerSociety.QuestLine, 4)
+				player:setStorageValue(Storage.ExplorerSociety.JoiningTheExplorers, 5)
+				player:setStorageValue(Storage.ExplorerSociety.QuestLine, 5)
 				npcHandler:say({
 					"Excellent, you brought just the tool we need! Of course it was only a simple task. However ...",
 					"I officially welcome you to the explorer society. From now on you can ask for missions to improve your rank."


### PR DESCRIPTION
# Description

Mortimer was not allowing the player to complete the "Joining the Explorers" quest.
The player was getting stuck into a loop of always having to provide a dwarven pickaxe and not advancing the questline.

## Behaviour
### **Actual**

![](https://user-images.githubusercontent.com/8331460/187549223-ee83425d-df2d-4187-a65c-c38cb402720d.PNG)
![](https://user-images.githubusercontent.com/8331460/187549468-503b193f-dfae-4256-a603-fc555964c971.png)

### **Expected**

The expected was to fill the quest and move to another missions.

![](https://user-images.githubusercontent.com/8331460/187549260-f64279b3-2c7e-4e78-8b6b-936a17b211c9.PNG)
![](https://user-images.githubusercontent.com/8331460/187549418-ae9f0bba-f02d-46cf-bc92-cacbc434edb9.png)

## Fixes

Angus has a different value for this section, so I've aligned to Mortimer set the same value:

https://github.com/opentibiabr/otservbr-global/blob/7b19d8169655e641fee138e4adc9ade6e8e2c957/data/npc/angus.lua#L390-L396

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Go to Mortimer, ask to join, then for a mission and delivery the pickaxe.
It might help to give you a lot of pickaxe to test with:
```
/i 4845, 5
```

**Test Configuration**:

  - Server Version: 1.4.0
  - Client: 12.86
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
