### PR TITLE
Fix unGreet function in npc cassino

### DIFF
--- a/data/npc/cassino.lua
+++ b/data/npc/cassino.lua
@@ -144,7 +144,7 @@ local function creatureSayCallback(npc, creature, type, message)
 	end
 
 	if player:getPosition() ~= config.playerPosition then
-		npcHandler:unGreet(creature)
+		npcHandler:unGreet(npc, creature)
 		return false
 	end
 	if table.contains({"low", "high", "h", "l", "1", "2", "3", "4", "5", "6", "odd", "impar", "par", "even"}, message) then


### PR DESCRIPTION
# Description

Just adding `npc` to the `unGreet` function, otherwise it would throw an error.

## Behaviour
### **Actual**

Errors when ungreeting.

### **Expected**

Ungreet the player.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

By adding another UnGreet to another NPC and run into that error.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
