### PR TITLE
[Sync] added option for enable or disable emoted spells for each player

### DIFF
--- a/data/scripts/actions/quests/heart_of_destruction/outburst_lever.lua
+++ b/data/scripts/actions/quests/heart_of_destruction/outburst_lever.lua
@@ -88,6 +88,9 @@ function heartDestructionOutburst.onUse(player, item, fromPosition, itemEx, toPo
 
 					for i = 1, #storePlayers do
 						players = storePlayers[i]
+						if players:getStorageValue(14331) >= os.time() then
+							return players:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You need wait to fight again")
+						end
 						config.playerPositions[i]:sendMagicEffect(CONST_ME_POFF)
 						players:teleportTo(config.newPos)
 						players:setStorageValue(14331, os.time() + 20*60*60)

--- a/data/scripts/talkactions/player/emote_spell.lua
+++ b/data/scripts/talkactions/player/emote_spell.lua
@@ -1,0 +1,19 @@
+local emoteSpell = TalkAction("!emote")
+
+function emoteSpell.onSay(player, words, param)
+	if param == "" then
+		player:sendCancelMessage("You need to specify on/off param.")
+		return false
+	end
+	if param == "on" then
+		player:setStorageValue(STORAGEVALUE_EMOTE, 1)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You activated emoted spells")
+	elseif param == "off" then
+		player:setStorageValue(STORAGEVALUE_EMOTE, 0)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You desactivated emoted spells")
+	end
+	return true
+end
+
+emoteSpell:separator(" ")
+emoteSpell:register()


### PR DESCRIPTION
This pr need the canary commit for work: https://github.com/opentibiabr/canary/commit/a37fc6f230226c4b439c3065226dc4047dfd70b0

Fixed a small bug on lever boss

Option is used with talkaction, but can be customized to be per item, store, etc.
To use, just activate with talkaction "!emote on" or "!emote off"