### PR TITLE
Fix hireling_lib crash on server startup

### DIFF
--- a/data/startup/others/hireling_lib.lua
+++ b/data/startup/others/hireling_lib.lua
@@ -103,7 +103,7 @@ local function checkHouseAccess(hireling)
 	-- player is not invited anymore, return to lamp
 	Spdlog.info("Returning Hireling:" .. hireling:getName() .. " to owner Inbox")
 	local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-	local lamp = inbox:addItem(HIRELING_LAMP_ID, 1)
+	local lamp = inbox:addItem(HIRELING_LAMP_ID, 1, INDEX_WHEREEVER, FLAG_NOLIMIT) -- Using FLAG_NOLIMIT to avoid losing the hireling after being kicked out of the house and having no slots available in the store inbox
 	lamp:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "This mysterious lamp summons your very own personal hireling.\nThis item cannot be traded.\nThis magic lamp is the home of " .. hireling:getName() .. ".")
 	lamp:setSpecialAttribute(HIRELING_ATTRIBUTE, hireling:getId()) --save hirelingId on item
 	player:save()
@@ -378,7 +378,7 @@ function Hireling:returnToLamp(player_id)
 		end
 
 		local inbox = owner:getSlotItem(CONST_SLOT_STORE_INBOX)
-		if not inbox or inbox:getEmptySlots() == 0 then
+		if not inbox or inbox:getEmptySlots() < 1 then
 			owner:getPosition():sendMagicEffect(CONST_ME_POFF)
 			return owner:sendTextMessage(MESSAGE_FAILURE, "You don't have enough room in your inbox.")
 		end
@@ -389,7 +389,7 @@ function Hireling:returnToLamp(player_id)
 		end
 
 		npc:say("As you wish!",	TALKTYPE_PRIVATE_NP, false, owner, npc:getPosition())
-		local lamp = inbox:addItem(HIRELING_LAMP_ID, 1)
+		local lamp = inbox:addItem(HIRELING_LAMP_ID, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 		npc:getPosition():sendMagicEffect(CONST_ME_PURPLESMOKE)
 		npc:remove() --remove hireling
 		lamp:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "This mysterious lamp summons your very own personal hireling.\nThis item cannot be traded.\nThis magic lamp is the home of " .. self:getName() .. ".")
@@ -525,7 +525,7 @@ function Player:addNewHireling(name, sex)
 	end
 
 	local inbox = self:getSlotItem(CONST_SLOT_STORE_INBOX)
-	if not inbox or inbox:getEmptySlots() == 0 then
+	if not inbox or inbox:getEmptySlots() < 1 then
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)
 		self:sendTextMessage(MESSAGE_FAILURE, "You don't have enough room in your inbox.")
 		return false
@@ -541,7 +541,7 @@ function Player:addNewHireling(name, sex)
 		end
 		table.insert(PLAYER_HIRELINGS[self:getGuid()], hireling)
 		table.insert(HIRELINGS, hireling)
-		local lamp = inbox:addItem(HIRELING_LAMP_ID, 1)
+		local lamp = inbox:addItem(HIRELING_LAMP_ID, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 		lamp:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "This mysterious lamp summons your very own personal hireling.\nThis item cannot be traded.\nThis magic lamp is the home of " .. hireling:getName() .. ".")
 		lamp:setSpecialAttribute(HIRELING_ATTRIBUTE, hireling:getId()) --save hirelingId on item
 		hireling.active = 0


### PR DESCRIPTION
# Description
- Using FLAG_NOLIMIT when returning the hireling lamp to user's store inbox.
- Ignoring the inbox available slots in this case avoids a crash in the hireling_lib file when the user losing the house has a full store inbox.


## Behaviour
### **Actual**
hireling_lib.lua crashes on a specific scenario on server startup

### **Expected**

Server startup must not crash
## Fixes
Fixes opentibiabr/canary#607 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Using a player without any available slots in the store inbox, that owns a house with a hireling spawned inside, setup this house to be freed upon the server save. On the server save, the hireling lamp is added to the store inbox and the startup continues without errors.

**Test Configuration**:

  - Server Version: 
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
